### PR TITLE
Extend and middleware fix, ts version bump, readme

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -2,13 +2,37 @@
 
 Comparison of runtime behavior (`index.js`) vs type declarations (`index.d.ts`).
 
+## Resolution status (vs current tree)
+
+| # | Status | Notes |
+|---|--------|--------|
+| 1 | **Fixed** | `Role.observe` is `"observe"` in `index.d.ts`. |
+| 2 | **Fixed** | `Role.start` is present in `index.d.ts`. |
+| 3 | **Fixed** | `Property` / `PropertyDescriptor` `role` includes `observe` and `start`. |
+| 4 | **Fixed** | Constructor is `constructor(interfaceDescriptor?: Property<string, any>[]?)`. |
+| 5 | **Fixed** | `extend` overloads accept `T \| T[]` / `PropertyDescriptor<K>[]`. |
+| 6 | **Fixed** | `Resolver` is variadic (`...rest: unknown[]`). |
+| 7 | **Fixed** | Runtime `removerCb` returns `this` when purging all; types match. |
+| 8 | **Fixed** | `getRolesHandlers(role, defaultsOnly?: boolean)` is declared. |
+| 9 | **Fixed** | `DefaultInterfaces.always` is `DoneType \| ErrorType` (no extra `Error`). |
+| 10 | **Open** | Shorthand instance accessors still not on the class type. |
+| 11 | **Open** | Several static helpers still missing from `index.d.ts` (see section). |
+| 12 | **Open** | `destroyed` still not declared on the class. |
+| 13 | **Open** | `Property.description` still not declared. |
+| 14 | **Fixed** | `pipe`: single guard, early `return this` (aligned with d.ts). |
+| 15 | **Open** | Two runtime role dictionaries (`JarvisEmitter.Role` vs `get role()`) unchanged. |
+| 16 | **Open** | CJS export vs ESM-style default in typings (consumer/tsconfig concern). |
+
 ---
 
 ## Critical — Type/Behavior Mismatches
 
 ### 1. `Role` enum typo: `"obsereve"` instead of `"observe"`
 
-**d.ts line 6:**
+**Status:** Fixed — enum member is `observe = "observe"`.
+
+Previously in typings (wrong):
+
 ```ts
 observe = "obsereve"
 ```
@@ -18,11 +42,13 @@ observe = "obsereve"
 observe: "observe"
 ```
 
-Anyone comparing `Role.observe` against a runtime string will get a mismatch.
+Anyone comparing `Role.observe` against a runtime string would have seen a mismatch before the typings were corrected.
 
 ---
 
 ### 2. `Role` enum missing `start`
+
+**Status:** Fixed — `start` is in `Role` in `index.d.ts`.
 
 JS defines a `start` role:
 
@@ -31,7 +57,7 @@ JS defines a `start` role:
 static get role() {
   return {
     done: "done",
-    start: "start",       // <-- missing from d.ts
+    start: "start",
     catchException: "catch",
     notify: "notify",
     event: "event",
@@ -40,38 +66,41 @@ static get role() {
 }
 ```
 
-The `Role` enum in d.ts has no `start` member. Code that uses `JarvisEmitter.role.start` has no type coverage.
+The `Role` enum in `index.d.ts` now includes `start`.
 
 ---
 
 ### 3. `Property.role` is too restrictive
+
+**Status:** Fixed — `role` allows `event`, `notify`, `observe`, and `start`.
+
+Previously typings were too narrow:
 
 ```ts
 // index.d.ts:11
 role: Role.event | Role.notify;
 ```
 
-This means users can only `extend()` with `event` or `notify` roles. But JS also allows `observe` (and `start`) since only `done` and `catchException` are removed from `_allowedRoles` after construction. `Role.observe` should be included.
+JS also allows `observe` and `start` (only `done` and `catchException` are removed from `_allowedRoles` after construction); typings now include those roles.
 
 ---
 
 ### 4. Constructor accepts an argument — d.ts says it doesn't
+
+**Status:** Fixed — `constructor(interfaceDescriptor?: Property<string, any>[])` in `index.d.ts`.
 
 **JS:**
 ```js
 constructor(interfaceDescriptor = [])
 ```
 
-**d.ts:**
-```ts
-constructor();
-```
-
-Users can pass initial interface descriptors to the constructor, but the type says no parameters.
+Previously **d.ts** had `constructor();`. It now accepts an optional `Property<string, any>[]`.
 
 ---
 
 ### 5. `extend()` accepts an array — d.ts says single object only
+
+**Status:** Fixed — overloads use `T | T[]` and `PropertyDescriptor<K> | PropertyDescriptor<K>[]`.
 
 **JS:**
 ```js
@@ -83,62 +112,63 @@ extend(interfaceDescription = []) {
 }
 ```
 
-**d.ts:**
+Previously **d.ts** accepted only a single descriptor:
+
 ```ts
-extend<K extends string, V, T extends Property<K, V>>(interfaceProps: T): JarvisEmitter<...>;
+extend<...>(interfaceProps: T): JarvisEmitter<...>;
 ```
 
-The type only accepts a single `Property`. JS accepts `Property | Property[]`.
+**d.ts** now accepts `T | T[]` (and the `PropertyDescriptor` overload accepts arrays). JS still accepts `Property | Property[]`.
 
 ---
 
 ### 6. `Resolver` is typed as single-arg, JS is variadic
 
-**d.ts:**
+**Status:** Fixed — `Resolver` includes `...rest: unknown[]`.
+
+Previously **d.ts**:
+
 ```ts
 type Resolver<...> = (arg: Interfaces[K]) => J;
 ```
+
+**d.ts** now uses `(arg, ...rest: unknown[]) => JarvisEmitter<...>`.
 
 **JS:**
 ```js
 const resolverCb = (...args) => { ... }
 ```
 
-Callers can do `emitter.call.done(a, b, c)` at runtime, but the type only allows one argument. Listeners also receive `...resolveArgs` spread.
-
 ---
 
 ### 7. `Remover` returns `undefined` when called without a listener
 
-**d.ts:**
-```ts
-type Remover<...> = (listener?: ...) => J;
-```
+**Status:** Fixed — runtime returns `this` on purge-all; `Remover` return type is `JarvisEmitter<...>`.
 
-Always returns `J`.
+**d.ts** types `Remover` as returning `JarvisEmitter<...>`.
 
-**JS:**
+**JS** (current): purge-all returns `this`:
+
 ```js
 const removerCb = (cb) => {
   if (!cb) {
     callbackArray.splice(0, callbackArray.length);
-    return;       // <-- returns undefined
+    return this;
   }
   // ...
   return this;
 };
 ```
 
-When called with no argument (purge all listeners), returns `undefined` — breaks chaining.
+Older versions returned bare `return` on purge-all, which broke chaining; runtime and typings are aligned now.
 
 ---
 
 ### 8. `getRolesHandlers` has a second parameter not in d.ts
 
-**d.ts:**
-```ts
-getRolesHandlers(role: Role): InterfaceEntry<...>[];
-```
+**Status:** Fixed — `getRolesHandlers(role, defaultsOnly?: boolean)` is declared.
+
+Previously **d.ts** listed only `getRolesHandlers(role: Role)`.
 
 **JS:**
 ```js
@@ -151,11 +181,13 @@ getRolesHandlers(role, defaultsOnly) {
 }
 ```
 
-The `defaultsOnly?: boolean` parameter is untyped.
-
 ---
 
 ### 9. `DefaultInterfaces.always` type includes `Error` but `catch` never triggers `always`
+
+**Status:** Fixed — `always` is `DoneType | ErrorType` in `index.d.ts`.
+
+Previously:
 
 ```ts
 always: DoneType | ErrorType | Error;
@@ -175,6 +207,8 @@ if (JarvisEmitter.role.done === property.role && "always" !== property.name) {
 ## Moderate — Missing API Surface in d.ts
 
 ### 10. Shorthand instance accessors completely untyped
+
+**Status:** Open — still not declared on `JarvisEmitter` in `index.d.ts`.
 
 For every non-reserved interface name, JS creates direct accessors on the instance:
 
@@ -200,6 +234,8 @@ None of these are in d.ts.
 
 ### 11. Missing static methods
 
+**Status:** Open — `emitifyFromAsync` / `all` / `some` are declared; the table below lists helpers still missing from typings.
+
 | Method | JS | d.ts |
 |---|---|---|
 | `static immediate(result, role?, name?)` | line 505 | missing |
@@ -213,11 +249,15 @@ None of these are in d.ts.
 
 ### 12. Missing `destroyed` instance property
 
+**Status:** Open — still not declared in `index.d.ts`.
+
 JS sets `this.destroyed = false` in constructor and `this.destroyed = true` in `destroy()`. Not declared in d.ts.
 
 ---
 
 ### 13. `Property` interface missing `description` field
+
+**Status:** Open — `description` still not on `Property` in `index.d.ts`.
 
 `JarvisEmitterInterfaceBuilder` has a `.description(desc)` method, so the built object can have a `description` field. The `Property` interface in d.ts doesn't include it.
 
@@ -227,18 +267,23 @@ JS sets `this.destroyed = false` in constructor and `this.destroyed = true` in `
 
 ### 14. `pipe()` has a duplicate guard condition
 
+**Status:** Fixed — `if (!pipedPromise) { return this; }`.
+
+Previously (bug):
+
 ```js
-// index.js:331
-if (!pipedPromise || !pipedPromise) {  // same check twice
-  return;   // returns undefined, d.ts says JarvisEmitter
+if (!pipedPromise || !pipedPromise) {
+  return;
 }
 ```
 
-Likely meant `!pipedPromise || !pipedPromise._nameMap` or similar. Also returns `undefined` on that branch — type says it always returns `JarvisEmitter`.
+Current `index.js` matches `pipe(): JarvisEmitter<...>` in `index.d.ts`.
 
 ---
 
 ### 15. `JarvisEmitter.Role` (static prop) vs `static get role()` — two different role objects
+
+**Status:** Open — runtime still exposes two dictionaries with different keys.
 
 ```js
 // static getter — line 423
@@ -255,24 +300,9 @@ Two role dictionaries exist at runtime with different keys. Only the `Role` enum
 
 ---
 
-### 16. `extend()` validation bug in JS
+### 16. Module export style mismatch
 
-```js
-// index.js:149
-if (undefined === property.role && -1 !== this._allowedRoles.indexOf(property.role)) {
-  continue;
-}
-```
-
-This condition is `role === undefined && role IS in allowedRoles`. Since `undefined` is never in `_allowedRoles`, this branch is dead code. Likely should be `||` instead of `&&`:
-
-```js
-if (undefined === property.role || -1 === this._allowedRoles.indexOf(property.role)) {
-```
-
----
-
-### 17. Module export style mismatch
+**Status:** Open — inherent CJS vs ESM interop; unchanged.
 
 **JS:** `module.exports = JarvisEmitter` (CommonJS)
 **d.ts:** `export default JarvisEmitter` (ES module default)
@@ -283,22 +313,21 @@ Works with `esModuleInterop: true`, but without it consumers need `import Jarvis
 
 ## Summary Table
 
-| # | Severity | Issue |
-|---|----------|-------|
-| 1 | **Critical** | `Role.observe` value is `"obsereve"` (typo) |
-| 2 | **Critical** | `Role` enum missing `start` |
-| 3 | **Critical** | `Property.role` excludes `observe` (and `start`) |
-| 4 | **Critical** | Constructor param untyped |
-| 5 | **Critical** | `extend()` doesn't accept arrays |
-| 6 | **Critical** | `Resolver` should be variadic |
-| 7 | **Critical** | `Remover` returns `undefined` on purge-all |
-| 8 | **Critical** | `getRolesHandlers` missing `defaultsOnly` param |
-| 9 | **Critical** | `always` type includes unreachable `Error` |
-| 10 | Moderate | Shorthand accessors (`.done()`, `.error()`, etc.) untyped |
-| 11 | Moderate | 6 static methods missing from d.ts |
-| 12 | Moderate | `destroyed` property missing from d.ts |
-| 13 | Moderate | `Property.description` field missing |
-| 14 | Minor | `pipe()` duplicate guard + returns `undefined` |
-| 15 | Minor | Two different `Role` objects at runtime |
-| 16 | Minor | Dead-code validation bug in `extend()` |
-| 17 | Minor | CommonJS vs ES module default export |
+| # | Severity | Issue | Status |
+|---|----------|-------|--------|
+| 1 | **Critical** | `Role.observe` value was `"obsereve"` (typo) | Fixed |
+| 2 | **Critical** | `Role` enum missing `start` | Fixed |
+| 3 | **Critical** | `Property.role` excluded `observe` (and `start`) | Fixed |
+| 4 | **Critical** | Constructor param untyped | Fixed |
+| 5 | **Critical** | `extend()` didn't accept arrays in typings | Fixed |
+| 6 | **Critical** | `Resolver` should be variadic | Fixed |
+| 7 | **Critical** | `Remover` / purge-all chaining | Fixed |
+| 8 | **Critical** | `getRolesHandlers` missing `defaultsOnly` param | Fixed |
+| 9 | **Critical** | `always` type included unreachable `Error` | Fixed |
+| 10 | Moderate | Shorthand accessors (`.done()`, `.error()`, etc.) untyped | Open |
+| 11 | Moderate | Several static methods still missing from d.ts | Open |
+| 12 | Moderate | `destroyed` property missing from d.ts | Open |
+| 13 | Moderate | `Property.description` field missing | Open |
+| 14 | Minor | `pipe()` duplicate guard + early return | Fixed |
+| 15 | Minor | Two different `Role` objects at runtime | Open |
+| 16 | Minor | CommonJS vs ES module default export | Open |

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,304 @@
+# jarvis-emitter Audit Report
+
+Comparison of runtime behavior (`index.js`) vs type declarations (`index.d.ts`).
+
+---
+
+## Critical — Type/Behavior Mismatches
+
+### 1. `Role` enum typo: `"obsereve"` instead of `"observe"`
+
+**d.ts line 6:**
+```ts
+observe = "obsereve"
+```
+
+**JS line 429:**
+```js
+observe: "observe"
+```
+
+Anyone comparing `Role.observe` against a runtime string will get a mismatch.
+
+---
+
+### 2. `Role` enum missing `start`
+
+JS defines a `start` role:
+
+```js
+// index.js:427
+static get role() {
+  return {
+    done: "done",
+    start: "start",       // <-- missing from d.ts
+    catchException: "catch",
+    notify: "notify",
+    event: "event",
+    observe: "observe"
+  };
+}
+```
+
+The `Role` enum in d.ts has no `start` member. Code that uses `JarvisEmitter.role.start` has no type coverage.
+
+---
+
+### 3. `Property.role` is too restrictive
+
+```ts
+// index.d.ts:11
+role: Role.event | Role.notify;
+```
+
+This means users can only `extend()` with `event` or `notify` roles. But JS also allows `observe` (and `start`) since only `done` and `catchException` are removed from `_allowedRoles` after construction. `Role.observe` should be included.
+
+---
+
+### 4. Constructor accepts an argument — d.ts says it doesn't
+
+**JS:**
+```js
+constructor(interfaceDescriptor = [])
+```
+
+**d.ts:**
+```ts
+constructor();
+```
+
+Users can pass initial interface descriptors to the constructor, but the type says no parameters.
+
+---
+
+### 5. `extend()` accepts an array — d.ts says single object only
+
+**JS:**
+```js
+extend(interfaceDescription = []) {
+  if (!Array.isArray(interfaceDescription)) {
+    interfaceDescription = [interfaceDescription];
+  }
+  // iterates over array...
+}
+```
+
+**d.ts:**
+```ts
+extend<K extends string, V, T extends Property<K, V>>(interfaceProps: T): JarvisEmitter<...>;
+```
+
+The type only accepts a single `Property`. JS accepts `Property | Property[]`.
+
+---
+
+### 6. `Resolver` is typed as single-arg, JS is variadic
+
+**d.ts:**
+```ts
+type Resolver<...> = (arg: Interfaces[K]) => J;
+```
+
+**JS:**
+```js
+const resolverCb = (...args) => { ... }
+```
+
+Callers can do `emitter.call.done(a, b, c)` at runtime, but the type only allows one argument. Listeners also receive `...resolveArgs` spread.
+
+---
+
+### 7. `Remover` returns `undefined` when called without a listener
+
+**d.ts:**
+```ts
+type Remover<...> = (listener?: ...) => J;
+```
+
+Always returns `J`.
+
+**JS:**
+```js
+const removerCb = (cb) => {
+  if (!cb) {
+    callbackArray.splice(0, callbackArray.length);
+    return;       // <-- returns undefined
+  }
+  // ...
+  return this;
+};
+```
+
+When called with no argument (purge all listeners), returns `undefined` — breaks chaining.
+
+---
+
+### 8. `getRolesHandlers` has a second parameter not in d.ts
+
+**d.ts:**
+```ts
+getRolesHandlers(role: Role): InterfaceEntry<...>[];
+```
+
+**JS:**
+```js
+getRolesHandlers(role, defaultsOnly) {
+  if (undefined === defaultsOnly)
+    return /* all */;
+  if (defaultsOnly)
+    return /* defaults only */;
+  return /* user-created only */;
+}
+```
+
+The `defaultsOnly?: boolean` parameter is untyped.
+
+---
+
+### 9. `DefaultInterfaces.always` type includes `Error` but `catch` never triggers `always`
+
+```ts
+always: DoneType | ErrorType | Error;
+```
+
+At runtime, `always` is only called when a handler with `role === "done"` resolves **and** the name isn't `"always"` itself:
+```js
+if (JarvisEmitter.role.done === property.role && "always" !== property.name) {
+  this.call.always(...resolveArgs);
+}
+```
+
+`catch` has role `catchException`, so it never triggers `always`. The `Error` in the union is unreachable — type should be `DoneType | ErrorType`.
+
+---
+
+## Moderate — Missing API Surface in d.ts
+
+### 10. Shorthand instance accessors completely untyped
+
+For every non-reserved interface name, JS creates direct accessors on the instance:
+
+```js
+// index.js:294-298
+if (-1 === reservedInterfaceNames.indexOf(property.name)) {
+  this[registerer] = registererCb;    // e.g. emitter.done(cb)
+  this[remover] = removerCb;          // e.g. emitter.offDone(cb)
+  this[resolver] = resolverCb;        // e.g. emitter.callDone(arg)
+  this[middleware] = middlewareCb;     // e.g. emitter.middlewareDone(cb)
+}
+```
+
+This means `emitter.done(cb)`, `emitter.error(cb)`, etc. work at runtime. The library's own `static all()` uses these:
+
+```js
+prom.done((result) => { ... }).error(promise.call.error);
+```
+
+None of these are in d.ts.
+
+---
+
+### 11. Missing static methods
+
+| Method | JS | d.ts |
+|---|---|---|
+| `static immediate(result, role?, name?)` | line 505 | missing |
+| `static emitify(fn, resultsAsArray?, cbIndex?)` | line 516 | missing |
+| `static interfaceProperty()` | line 415 | missing |
+| `static get role()` | line 423 | missing |
+| `static onUnhandledException(cb)` | line 547 | missing |
+| `static offUnhandledException(cb)` | line 551 | missing |
+
+---
+
+### 12. Missing `destroyed` instance property
+
+JS sets `this.destroyed = false` in constructor and `this.destroyed = true` in `destroy()`. Not declared in d.ts.
+
+---
+
+### 13. `Property` interface missing `description` field
+
+`JarvisEmitterInterfaceBuilder` has a `.description(desc)` method, so the built object can have a `description` field. The `Property` interface in d.ts doesn't include it.
+
+---
+
+## Minor — Consistency / Style Issues
+
+### 14. `pipe()` has a duplicate guard condition
+
+```js
+// index.js:331
+if (!pipedPromise || !pipedPromise) {  // same check twice
+  return;   // returns undefined, d.ts says JarvisEmitter
+}
+```
+
+Likely meant `!pipedPromise || !pipedPromise._nameMap` or similar. Also returns `undefined` on that branch — type says it always returns `JarvisEmitter`.
+
+---
+
+### 15. `JarvisEmitter.Role` (static prop) vs `static get role()` — two different role objects
+
+```js
+// static getter — line 423
+static get role() {
+  return { done, start, catchException, notify, event, observe };
+}
+
+// static property — line 574
+JarvisEmitter.Role = { done, catchException, notify, event, observe };
+// note: no "start"
+```
+
+Two role dictionaries exist at runtime with different keys. Only the `Role` enum is in d.ts.
+
+---
+
+### 16. `extend()` validation bug in JS
+
+```js
+// index.js:149
+if (undefined === property.role && -1 !== this._allowedRoles.indexOf(property.role)) {
+  continue;
+}
+```
+
+This condition is `role === undefined && role IS in allowedRoles`. Since `undefined` is never in `_allowedRoles`, this branch is dead code. Likely should be `||` instead of `&&`:
+
+```js
+if (undefined === property.role || -1 === this._allowedRoles.indexOf(property.role)) {
+```
+
+---
+
+### 17. Module export style mismatch
+
+**JS:** `module.exports = JarvisEmitter` (CommonJS)
+**d.ts:** `export default JarvisEmitter` (ES module default)
+
+Works with `esModuleInterop: true`, but without it consumers need `import JarvisEmitter = require('jarvis-emitter')`.
+
+---
+
+## Summary Table
+
+| # | Severity | Issue |
+|---|----------|-------|
+| 1 | **Critical** | `Role.observe` value is `"obsereve"` (typo) |
+| 2 | **Critical** | `Role` enum missing `start` |
+| 3 | **Critical** | `Property.role` excludes `observe` (and `start`) |
+| 4 | **Critical** | Constructor param untyped |
+| 5 | **Critical** | `extend()` doesn't accept arrays |
+| 6 | **Critical** | `Resolver` should be variadic |
+| 7 | **Critical** | `Remover` returns `undefined` on purge-all |
+| 8 | **Critical** | `getRolesHandlers` missing `defaultsOnly` param |
+| 9 | **Critical** | `always` type includes unreachable `Error` |
+| 10 | Moderate | Shorthand accessors (`.done()`, `.error()`, etc.) untyped |
+| 11 | Moderate | 6 static methods missing from d.ts |
+| 12 | Moderate | `destroyed` property missing from d.ts |
+| 13 | Moderate | `Property.description` field missing |
+| 14 | Minor | `pipe()` duplicate guard + returns `undefined` |
+| 15 | Minor | Two different `Role` objects at runtime |
+| 16 | Minor | Dead-code validation bug in `extend()` |
+| 17 | Minor | CommonJS vs ES module default export |

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -21,7 +21,7 @@ Comparison of runtime behavior (`index.js`) vs type declarations (`index.d.ts`).
 | 13 | **Open** | `Property.description` still not declared. |
 | 14 | **Fixed** | `pipe`: single guard, early `return this` (aligned with d.ts). |
 | 15 | **Open** | Two runtime role dictionaries (`JarvisEmitter.Role` vs `get role()`) unchanged. |
-| 16 | **Open** | CJS export vs ESM-style default in typings (consumer/tsconfig concern). |
+| 16 | **Fixed** | `index.d.ts` uses `export = JarvisEmitter` with merged namespace (matches `module.exports`). |
 
 ---
 
@@ -302,12 +302,13 @@ Two role dictionaries exist at runtime with different keys. Only the `Role` enum
 
 ### 16. Module export style mismatch
 
-**Status:** Open — inherent CJS vs ESM interop; unchanged.
+**Status:** Fixed — typings use `export = JarvisEmitter` (CommonJS-compatible). `Role`, `Property`, `PropertyDescriptor`, and `DefaultInterfaces` live in a merged `declare namespace JarvisEmitter`.
 
 **JS:** `module.exports = JarvisEmitter` (CommonJS)
-**d.ts:** `export default JarvisEmitter` (ES module default)
 
-Works with `esModuleInterop: true`, but without it consumers need `import JarvisEmitter = require('jarvis-emitter')`.
+**d.ts:** `export = JarvisEmitter` with merged namespace (matches CJS).
+
+Consumers: `require()` works; `import JarvisEmitter = require('jarvis-emitter')` works without `esModuleInterop`, `import JarvisEmitter, { Role } from 'jarvis-emitter'` works with `esModuleInterop: true`, named exports resolve to `JarvisEmitter.Role` etc. at the type level.
 
 ---
 
@@ -330,4 +331,4 @@ Works with `esModuleInterop: true`, but without it consumers need `import Jarvis
 | 13 | Moderate | `Property.description` field missing | Open |
 | 14 | Minor | `pipe()` duplicate guard + early return | Fixed |
 | 15 | Minor | Two different `Role` objects at runtime | Open |
-| 16 | Minor | CommonJS vs ES module default export | Open |
+| 16 | Minor | CommonJS vs typings export style | Fixed |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
 # jarvis-emitter
+
+A typed, extensible event emitter with middleware support, sticky events, and promise interop.
+
+## Install
+
+```bash
+npm install jarvis-emitter
+```
+
+## Quick Start
+
+```js
+const JarvisEmitter = require("jarvis-emitter");
+// or ESM syntax
+import JarvisEmitter, { Role, } from "jarvis-emitter";
+
+const emitter = new JarvisEmitter();
+
+emitter.on.done((result) => console.log("Done:", result));
+emitter.on.error((err) => console.error("Error:", err));
+
+emitter.call.done("success");
+```
+
+## Extending with Custom Events
+
+```js
+const emitter = new JarvisEmitter()
+  .extend({ name: "progress", role: JarvisEmitter.role.event })
+  .extend({ name: "status", role: JarvisEmitter.role.notify });
+
+emitter.on.progress((pct) => console.log(`${pct}%`));
+emitter.call.progress(42);
+```
+
+### TypeScript
+
+```typescript
+import JarvisEmitter, { Role, type DefaultInterfaces } from "jarvis-emitter";
+
+type SensorStatus = {
+	value: number;
+	health: "ok" | "bad" | "error";
+};
+
+type DoneType = string;
+type ErrorType = Error;
+
+// Option #1 — infer types via .extend<K, V>(...)
+const emitter1 = new JarvisEmitter<DoneType, ErrorType>().extend<"changed", SensorStatus>({
+	name: "changed",
+	role: Role.event,
+});
+
+// Option #2 — explicit interface (full control, best for many custom events)
+interface SensorInterfaces extends DefaultInterfaces<DoneType, ErrorType> {
+	changed: SensorStatus;
+}
+
+const emitter2 = new JarvisEmitter<DoneType, ErrorType, SensorInterfaces>().extend({
+	name: "changed",
+	role: Role.event,
+});
+
+emitter1.on.changed((pct) => {}); // pct: SensorStatus
+emitter2.on.done((val) => {}); // val: string
+```
+
+## Middleware
+
+Transform emitted values before they reach listeners:
+
+```js
+emitter.middleware.done((next, val) => {
+  next(val.toUpperCase());
+});
+```
+
+## Sticky Events
+
+Events that replay to late subscribers:
+
+```js
+const emitter = new JarvisEmitter();
+emitter.call.done("already resolved");
+
+// Late subscriber still receives the value
+emitter.on.done((val) => console.log(val)); // "already resolved"
+```
+
+## Promise Interop
+
+```js
+const result = await emitter.promise();
+```
+
+## Static Helpers
+
+```js
+// Wait for all emitters
+const all = JarvisEmitter.all(emitterA, emitterB);
+
+// Wait for all, treating errors as undefined
+const some = JarvisEmitter.some(emitterA, emitterB);
+
+// Wrap an async function
+const emitified = JarvisEmitter.emitifyFromAsync(fetchData);
+```
+
+## Default Events
+
+Every emitter ships with: `done`, `error`, `always`, `catch`, `event`, `notify`, `tap`.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -8,12 +8,24 @@ A typed, extensible event emitter with middleware support, sticky events, and pr
 npm install jarvis-emitter
 ```
 
+The package is published as **CommonJS** (`module.exports`). Type definitions use `export =`, which matches that shape.
+
+### Importing (JavaScript and TypeScript)
+
+Pick one pattern:
+
+| Style | Example |
+|--------|---------|
+| **CommonJS** | `const JarvisEmitter = require("jarvis-emitter");` |
+| **TypeScript, no `esModuleInterop`** | `import JarvisEmitter = require("jarvis-emitter");` |
+| **TypeScript / bundlers with `esModuleInterop: true`** | `import JarvisEmitter, { Role, type DefaultInterfaces } from "jarvis-emitter";` |
+
+**Types:** `Role`, `Property`, `PropertyDescriptor`, and `DefaultInterfaces` live on the merged `JarvisEmitter` namespace in the typings. Destructured imports like `{ Role }` work when `esModuleInterop` is enabled. With `import JarvisEmitter = require("jarvis-emitter")`, use `JarvisEmitter.Role` (and the same pattern for other names). At runtime, `JarvisEmitter.Role` is also available on the constructor object from JS.
+
 ## Quick Start
 
 ```js
 const JarvisEmitter = require("jarvis-emitter");
-// or ESM syntax
-import JarvisEmitter, { Role, } from "jarvis-emitter";
 
 const emitter = new JarvisEmitter();
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Pick one pattern:
 |--------|---------|
 | **CommonJS** | `const JarvisEmitter = require("jarvis-emitter");` |
 | **TypeScript, no `esModuleInterop`** | `import JarvisEmitter = require("jarvis-emitter");` |
-| **TypeScript / bundlers with `esModuleInterop: true`** | `import JarvisEmitter, { Role, type DefaultInterfaces } from "jarvis-emitter";` |
+| **TypeScript / bundlers with `esModuleInterop: true`** | `import JarvisEmitter, { Role, payload, type DefaultInterfaces } from "jarvis-emitter";` |
 
-**Types:** `Role`, `Property`, `PropertyDescriptor`, and `DefaultInterfaces` live on the merged `JarvisEmitter` namespace in the typings. Destructured imports like `{ Role }` work when `esModuleInterop` is enabled. With `import JarvisEmitter = require("jarvis-emitter")`, use `JarvisEmitter.Role` (and the same pattern for other names). At runtime, `JarvisEmitter.Role` is also available on the constructor object from JS.
+**Types:** `Role`, `Property`, `PropertyDescriptor`, `DefaultInterfaces`, and `payload` live on the merged `JarvisEmitter` namespace in the typings. Destructured imports like `{ Role, payload }` work when `esModuleInterop` is enabled. With `import JarvisEmitter = require("jarvis-emitter")`, use `JarvisEmitter.Role`, `JarvisEmitter.payload`, and the same pattern for other names. At runtime, `JarvisEmitter.Role` and `JarvisEmitter.payload` are also available on the constructor object from JS.
 
 ## Quick Start
 
@@ -48,8 +48,12 @@ emitter.call.progress(42);
 
 ### TypeScript
 
+Payload types for custom names are spelled with **`withType()`** (chain-friendly) or **`payload()`** (inline on the descriptor). The old **`extend<"name", Type>(...)`** generic style is not supported; use one of the patterns below.
+
+**Chaining:** TypeScript only refines the emitter type from **chained** return values (e.g. `.withType<T>().extend(...).withType<U>().extend(...)`). If you assign `const em = new JarvisEmitter()` and call `em.extend(...)` several times without reassigning from the return value, the variable’s type does not pick up the new keys.
+
 ```typescript
-import JarvisEmitter, { Role, type DefaultInterfaces } from "jarvis-emitter";
+import JarvisEmitter, { Role, payload, type DefaultInterfaces } from "jarvis-emitter";
 
 type SensorStatus = {
 	value: number;
@@ -59,25 +63,40 @@ type SensorStatus = {
 type DoneType = string;
 type ErrorType = Error;
 
-// Option #1 — infer types via .extend<K, V>(...)
-const emitter1 = new JarvisEmitter<DoneType, ErrorType>().extend<"changed", SensorStatus>({
+// Option 1 — withType(): separate payload type from the inferred event name (good for chains)
+const emitter1 = new JarvisEmitter<DoneType, ErrorType>()
+	.withType<SensorStatus>()
+	.extend({ name: "changed", role: Role.event });
+
+// Option 2 — payload(): inline emittedType without type assertions (runtime value is unused)
+const emitter2 = new JarvisEmitter<DoneType, ErrorType>().extend({
 	name: "changed",
 	role: Role.event,
+	emittedType: payload<SensorStatus>(),
 });
 
-// Option #2 — explicit interface (full control, best for many custom events)
+// Option 3 — explicit interface map (best when you already model all events as one type)
 interface SensorInterfaces extends DefaultInterfaces<DoneType, ErrorType> {
 	changed: SensorStatus;
 }
 
-const emitter2 = new JarvisEmitter<DoneType, ErrorType, SensorInterfaces>().extend({
+const emitter3 = new JarvisEmitter<DoneType, ErrorType, SensorInterfaces>().extend({
 	name: "changed",
 	role: Role.event,
 });
 
-emitter1.on.changed((pct) => {}); // pct: SensorStatus
-emitter2.on.done((val) => {}); // val: string
+emitter1.on.changed((pct) => {
+	pct.health; // SensorStatus
+});
+emitter2.on.changed((pct) => {
+	pct.value; // SensorStatus
+});
+emitter3.on.done((val) => {
+	val; // string (DoneType)
+});
 ```
+
+New keys added with a plain descriptor (no `withType` / `payload` / interface entry) are typed as **`void`** payloads.
 
 ## Middleware
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,41 +1,3 @@
-export enum Role {
-	event = "event",
-	notify = "notify",
-	done = "done",
-	start = "start",
-	catchException = "catch", //
-	observe = "observe",
-}
-
-export interface Property<Name extends string, Value = any> {
-	name: Name;
-	role: Role.event | Role.notify | Role.observe | Role.start;
-	sticky?: boolean;
-	stickyLast?: boolean;
-	emittedType?: Value;
-}
-
-export interface PropertyDescriptor<Name extends string> {
-	name: Name;
-	role: Role.event | Role.notify | Role.observe | Role.start;
-	sticky?: boolean;
-	stickyLast?: boolean;
-}
-
-export interface DefaultInterfaces<DoneType = void, ErrorType = Error> {
-	done: DoneType;
-	error: ErrorType;
-	catch: Error;
-	always: DoneType | ErrorType;
-	event: any;
-	notify: any;
-	tap: {
-		name: string;
-		role?: Role;
-		data: any[];
-	};
-}
-
 type Registerer<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = (
 	listener: (arg: Interfaces[K]) => void,
 ) => JarvisEmitter<DoneType, ErrorType, Interfaces>;
@@ -58,7 +20,7 @@ interface InterfaceEntry<Interfaces, K extends keyof Interfaces, DoneType, Error
 	remover: Remover<Interfaces, K, DoneType, ErrorType>;
 	middleware: Middleware<Interfaces, K, DoneType, ErrorType>;
 	name: K;
-	role: Role;
+	role: JarvisEmitter.Role;
 	purge: Function;
 }
 
@@ -69,8 +31,12 @@ type ExtractJarvisEmitterErrorType<J extends JarvisEmitter<any, any>> = J extend
 	? ErrorType
 	: Error;
 
-declare class JarvisEmitter<DoneType = void, ErrorType = Error, Interfaces = DefaultInterfaces<DoneType, ErrorType>> {
-	constructor(interfaceDescriptor?: Property<string, any>[]);
+declare class JarvisEmitter<
+	DoneType = void,
+	ErrorType = Error,
+	Interfaces = JarvisEmitter.DefaultInterfaces<DoneType, ErrorType>,
+> {
+	constructor(interfaceDescriptor?: JarvisEmitter.Property<string, any>[]);
 	on: {
 		[key in keyof Interfaces]: Registerer<Interfaces, key, DoneType, ErrorType>;
 	};
@@ -91,21 +57,21 @@ declare class JarvisEmitter<DoneType = void, ErrorType = Error, Interfaces = Def
 	 * to avoid deeply nested types in long `.extend()` chains.
 	 */
 	extend<K extends keyof Interfaces & string>(
-		interfaceProps: PropertyDescriptor<K> | PropertyDescriptor<K>[],
+		interfaceProps: JarvisEmitter.PropertyDescriptor<K> | JarvisEmitter.PropertyDescriptor<K>[],
 	): JarvisEmitter<DoneType, ErrorType, Interfaces>;
 	extend<K extends string, V = K extends keyof Interfaces ? Interfaces[K] : void>(
-		interfaceProps: PropertyDescriptor<K> | PropertyDescriptor<K>[],
+		interfaceProps: JarvisEmitter.PropertyDescriptor<K> | JarvisEmitter.PropertyDescriptor<K>[],
 	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, V>>;
-	extend<K extends keyof Interfaces & string, V extends any, T extends Property<K, V>>(
+	extend<K extends keyof Interfaces & string, V extends any, T extends JarvisEmitter.Property<K, V>>(
 		interfaceProps: T | T[],
 	): JarvisEmitter<DoneType, ErrorType, Interfaces>;
-	extend<K extends string, V extends any, T extends Property<K, V>>(
+	extend<K extends string, V extends any, T extends JarvisEmitter.Property<K, V>>(
 		interfaceProps: T | T[],
 	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, T["name"]> & Record<T["name"], T["emittedType"]>>;
 	promise(): Promise<DoneType>;
 	pipe<T extends JarvisEmitter<any, any, any>>(emitter: T): JarvisEmitter<DoneType, ErrorType, Interfaces>;
 	getRolesHandlers(
-		role: Role,
+		role: JarvisEmitter.Role,
 		defaultsOnly?: boolean,
 	): InterfaceEntry<Interfaces, keyof Interfaces, DoneType, ErrorType>[];
 	getHandlersForName<T extends keyof Interfaces>(
@@ -124,4 +90,44 @@ declare class JarvisEmitter<DoneType = void, ErrorType = Error, Interfaces = Def
 	): (...callArgs: I) => JarvisEmitter<O, any>;
 }
 
-export default JarvisEmitter;
+declare namespace JarvisEmitter {
+	enum Role {
+		event = "event",
+		notify = "notify",
+		done = "done",
+		start = "start",
+		catchException = "catch", //
+		observe = "observe",
+	}
+
+	interface Property<Name extends string, Value = any> {
+		name: Name;
+		role: Role.event | Role.notify | Role.observe | Role.start;
+		sticky?: boolean;
+		stickyLast?: boolean;
+		emittedType?: Value;
+	}
+
+	interface PropertyDescriptor<Name extends string> {
+		name: Name;
+		role: Role.event | Role.notify | Role.observe | Role.start;
+		sticky?: boolean;
+		stickyLast?: boolean;
+	}
+
+	interface DefaultInterfaces<DoneType = void, ErrorType = Error> {
+		done: DoneType;
+		error: ErrorType;
+		catch: Error;
+		always: DoneType | ErrorType;
+		event: any;
+		notify: any;
+		tap: {
+			name: string;
+			role?: Role;
+			data: any[];
+		};
+	}
+}
+
+export = JarvisEmitter;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,8 @@
+/**
+ * Forces TypeScript to resolve and flatten intersections and Omits into a clean object type.
+ */
+type Simplify<T> = { [K in keyof T]: T[K] } & {};
+
 type Registerer<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = (
 	listener: (arg: Interfaces[K]) => void,
 ) => JarvisEmitter<DoneType, ErrorType, Interfaces>;
@@ -12,7 +17,7 @@ type Middleware<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = <
 	ChangedArg = Interfaces[K],
 >(
 	listener: (next: (arg: ChangedArg) => void, arg: Interfaces[K]) => void,
-) => JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, ChangedArg>>;
+) => JarvisEmitter<DoneType, ErrorType, Simplify<Omit<Interfaces, K> & Record<K, ChangedArg>>>;
 
 interface InterfaceEntry<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> {
 	registerer: Registerer<Interfaces, K, DoneType, ErrorType>;
@@ -21,7 +26,7 @@ interface InterfaceEntry<Interfaces, K extends keyof Interfaces, DoneType, Error
 	middleware: Middleware<Interfaces, K, DoneType, ErrorType>;
 	name: K;
 	role: JarvisEmitter.Role;
-	purge: Function;
+	purge: () => void;
 }
 
 type ExtractJarvisEmitterDoneType<J extends JarvisEmitter<any, any>> = J extends JarvisEmitter<infer DoneType, any>
@@ -50,24 +55,37 @@ declare class JarvisEmitter<
 		[key in keyof Interfaces]: Middleware<Interfaces, key, DoneType, ErrorType>;
 	};
 	/**
-	 * Adds named interfaces. Type parameter `V` defaults to `void` for keys not already on `Interfaces`,
-	 * and to the existing property type when `K` is already a key of `Interfaces`.
-	 *
-	 * When `K` is already in `Interfaces`, the return type is kept flat (no Omit/Record wrapping)
-	 * to avoid deeply nested types in long `.extend()` chains.
+	 * Re-extends an existing interface key using a descriptor without `emittedType` (preserves `Interfaces`).
 	 */
 	extend<K extends keyof Interfaces & string>(
 		interfaceProps: JarvisEmitter.PropertyDescriptor<K> | JarvisEmitter.PropertyDescriptor<K>[],
 	): JarvisEmitter<DoneType, ErrorType, Interfaces>;
-	extend<K extends string, V = K extends keyof Interfaces ? Interfaces[K] : void>(
-		interfaceProps: JarvisEmitter.PropertyDescriptor<K> | JarvisEmitter.PropertyDescriptor<K>[],
-	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, V>>;
+	/**
+	 * Re-extends an existing key with a full `Property` (including `emittedType` / `payload()`); preserves `Interfaces`.
+	 */
 	extend<K extends keyof Interfaces & string, V extends any, T extends JarvisEmitter.Property<K, V>>(
 		interfaceProps: T | T[],
 	): JarvisEmitter<DoneType, ErrorType, Interfaces>;
+	/**
+	 * Adds a new key (no `emittedType`); payload type defaults to `void`.
+	 */
+	extend<K extends string>(
+		interfaceProps: JarvisEmitter.PropertyDescriptor<K> | JarvisEmitter.PropertyDescriptor<K>[],
+	): JarvisEmitter<DoneType, ErrorType, Simplify<Omit<Interfaces, K> & Record<K, void>>>;
+	/**
+	 * Adds or overrides typing via `emittedType` (e.g. `payload<T>()`).
+	 */
 	extend<K extends string, V extends any, T extends JarvisEmitter.Property<K, V>>(
 		interfaceProps: T | T[],
-	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, T["name"]> & Record<T["name"], T["emittedType"]>>;
+	): JarvisEmitter<DoneType, ErrorType, Simplify<Omit<Interfaces, T["name"]> & Record<T["name"], T["emittedType"]>>>;
+	/**
+	 * Pre-defines the payload type for the next `.extend()` using a `PropertyDescriptor` (no `emittedType`).
+	 */
+	withType<V>(): {
+		extend<K extends string>(
+			interfaceProps: JarvisEmitter.PropertyDescriptor<K> | JarvisEmitter.PropertyDescriptor<K>[],
+		): JarvisEmitter<DoneType, ErrorType, Simplify<Omit<Interfaces, K> & Record<K, V>>>;
+	};
 	promise(): Promise<DoneType>;
 	pipe<T extends JarvisEmitter<any, any, any>>(emitter: T): JarvisEmitter<DoneType, ErrorType, Interfaces>;
 	getRolesHandlers(
@@ -108,12 +126,21 @@ declare namespace JarvisEmitter {
 		emittedType?: Value;
 	}
 
+	/**
+	 * Descriptor without `emittedType` — use {@link payload} or {@link JarvisEmitter#withType} for payload typing.
+	 */
 	interface PropertyDescriptor<Name extends string> {
 		name: Name;
 		role: Role.event | Role.notify | Role.observe | Role.start;
 		sticky?: boolean;
 		stickyLast?: boolean;
+		emittedType?: never;
 	}
+
+	/**
+	 * Type-only helper for `extend()` with `emittedType`. At runtime returns `undefined` (not read by `extend`).
+	 */
+	function payload<T>(): T;
 
 	interface DefaultInterfaces<DoneType = void, ErrorType = Error> {
 		done: DoneType;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export enum Role {
 	notify = "notify",
 	done = "done",
 	start = "start",
-	catchException = "catch", // 
+	catchException = "catch", //
 	observe = "observe",
 }
 
@@ -22,69 +22,106 @@ export interface PropertyDescriptor<Name extends string> {
 	stickyLast?: boolean;
 }
 
-type Omit<T, K> = { [key in Exclude<keyof T, K>]: T[key] };
-
 export interface DefaultInterfaces<DoneType = void, ErrorType = Error> {
 	done: DoneType;
 	error: ErrorType;
 	catch: Error;
 	always: DoneType | ErrorType;
 	event: any;
-	notify: any
+	notify: any;
 	tap: {
 		name: string;
 		role?: Role;
 		data: any[];
-	}
+	};
 }
 
-type Registerer<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = (listener: (arg: Interfaces[K]) => void) => J;
-type Resolver<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = (arg: Interfaces[K], ...rest: unknown[]) => J;
-type Remover<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = (listener?: (arg: Interfaces[K]) => void) => J;
-type Middleware<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = <ChangedArg = Interfaces[K]>(listener: (next: (arg: ChangedArg) => void, arg: Interfaces[K]) => void) =>
-	JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, ChangedArg>>;
+type Registerer<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = (
+	listener: (arg: Interfaces[K]) => void,
+) => JarvisEmitter<DoneType, ErrorType, Interfaces>;
+type Resolver<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = (
+	arg: Interfaces[K],
+	...rest: unknown[]
+) => JarvisEmitter<DoneType, ErrorType, Interfaces>;
+type Remover<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = (
+	listener?: (arg: Interfaces[K]) => void,
+) => JarvisEmitter<DoneType, ErrorType, Interfaces>;
+type Middleware<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = <
+	ChangedArg = Interfaces[K],
+>(
+	listener: (next: (arg: ChangedArg) => void, arg: Interfaces[K]) => void,
+) => JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, ChangedArg>>;
 
-interface InterfaceEntry<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>, DoneType, ErrorType> {
-	registerer: Registerer<Interfaces, K, J>;
-	resolver: Resolver<Interfaces, K, J>;
-	remover: Remover<Interfaces, K, J>;
+interface InterfaceEntry<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> {
+	registerer: Registerer<Interfaces, K, DoneType, ErrorType>;
+	resolver: Resolver<Interfaces, K, DoneType, ErrorType>;
+	remover: Remover<Interfaces, K, DoneType, ErrorType>;
 	middleware: Middleware<Interfaces, K, DoneType, ErrorType>;
 	name: K;
 	role: Role;
 	purge: Function;
 }
 
-type ExtractJarvisEmitterDoneType<J extends JarvisEmitter<any, any>> = J extends JarvisEmitter<infer DoneType, any> ? DoneType : void;
-type ExtractJarvisEmitterErrorType<J extends JarvisEmitter<any, any>> = J extends JarvisEmitter<any, infer ErrorType> ? ErrorType : Error;
+type ExtractJarvisEmitterDoneType<J extends JarvisEmitter<any, any>> = J extends JarvisEmitter<infer DoneType, any>
+	? DoneType
+	: void;
+type ExtractJarvisEmitterErrorType<J extends JarvisEmitter<any, any>> = J extends JarvisEmitter<any, infer ErrorType>
+	? ErrorType
+	: Error;
 
 declare class JarvisEmitter<DoneType = void, ErrorType = Error, Interfaces = DefaultInterfaces<DoneType, ErrorType>> {
 	constructor(interfaceDescriptor?: Property<string, any>[]);
 	on: {
-		[key in keyof Interfaces]: Registerer<Interfaces, key, JarvisEmitter<DoneType, ErrorType, Interfaces>>
+		[key in keyof Interfaces]: Registerer<Interfaces, key, DoneType, ErrorType>;
 	};
 	call: {
-		[key in keyof Interfaces]: Resolver<Interfaces, key, JarvisEmitter<DoneType, ErrorType, Interfaces>>
+		[key in keyof Interfaces]: Resolver<Interfaces, key, DoneType, ErrorType>;
 	};
 	off: {
-		[key in keyof Interfaces]: Remover<Interfaces, key, JarvisEmitter<DoneType, ErrorType, Interfaces>>
+		[key in keyof Interfaces]: Remover<Interfaces, key, DoneType, ErrorType>;
 	};
 	middleware: {
-		[key in keyof Interfaces]: Middleware<Interfaces, key, DoneType, ErrorType>
+		[key in keyof Interfaces]: Middleware<Interfaces, key, DoneType, ErrorType>;
 	};
+	/**
+	 * Adds named interfaces. Type parameter `V` defaults to `void` for keys not already on `Interfaces`,
+	 * and to the existing property type when `K` is already a key of `Interfaces`.
+	 *
+	 * When `K` is already in `Interfaces`, the return type is kept flat (no Omit/Record wrapping)
+	 * to avoid deeply nested types in long `.extend()` chains.
+	 */
+	extend<K extends keyof Interfaces & string>(
+		interfaceProps: PropertyDescriptor<K> | PropertyDescriptor<K>[],
+	): JarvisEmitter<DoneType, ErrorType, Interfaces>;
 	extend<K extends string, V = K extends keyof Interfaces ? Interfaces[K] : void>(
-		interfaceProps: PropertyDescriptor<K> | PropertyDescriptor<K>[]
+		interfaceProps: PropertyDescriptor<K> | PropertyDescriptor<K>[],
 	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, V>>;
+	extend<K extends keyof Interfaces & string, V extends any, T extends Property<K, V>>(
+		interfaceProps: T | T[],
+	): JarvisEmitter<DoneType, ErrorType, Interfaces>;
 	extend<K extends string, V extends any, T extends Property<K, V>>(
-		interfaceProps: T | T[]
-	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, T["name"]> & { [key in T["name"]]: T["emittedType"] }>;
+		interfaceProps: T | T[],
+	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, T["name"]> & Record<T["name"], T["emittedType"]>>;
 	promise(): Promise<DoneType>;
 	pipe<T extends JarvisEmitter<any, any, any>>(emitter: T): JarvisEmitter<DoneType, ErrorType, Interfaces>;
-	getRolesHandlers(role: Role, defaultsOnly?: boolean): InterfaceEntry<Interfaces, keyof Interfaces, JarvisEmitter<DoneType, ErrorType, Interfaces>, DoneType, ErrorType>[];
-	getHandlersForName<T extends keyof Interfaces>(name: T, role?: string): InterfaceEntry<Interfaces, T, JarvisEmitter<DoneType, ErrorType, Interfaces>, DoneType, ErrorType>;
+	getRolesHandlers(
+		role: Role,
+		defaultsOnly?: boolean,
+	): InterfaceEntry<Interfaces, keyof Interfaces, DoneType, ErrorType>[];
+	getHandlersForName<T extends keyof Interfaces>(
+		name: T,
+		role?: string,
+	): InterfaceEntry<Interfaces, T, DoneType, ErrorType>;
 	destroy(): void;
-	static some<J extends Array<JarvisEmitter<any, any>>>(...emitters: J): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]> | undefined>, never>;
-	static all<J extends JarvisEmitter<any, any>[]>(...emitters: J): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]>>, ExtractJarvisEmitterErrorType<J[number]>>;
-	static emitifyFromAsync<I extends any[], O>(fn: (...args: I) => Promise<O>): (...callArgs: I) => JarvisEmitter<O, any>;
+	static some<J extends Array<JarvisEmitter<any, any>>>(
+		...emitters: J
+	): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]> | undefined>, never>;
+	static all<J extends JarvisEmitter<any, any>[]>(
+		...emitters: J
+	): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]>>, ExtractJarvisEmitterErrorType<J[number]>>;
+	static emitifyFromAsync<I extends any[], O>(
+		fn: (...args: I) => Promise<O>,
+	): (...callArgs: I) => JarvisEmitter<O, any>;
 }
 
 export default JarvisEmitter;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,16 +2,24 @@ export enum Role {
 	event = "event",
 	notify = "notify",
 	done = "done",
-	catchException = "catch",
-	observe = "obsereve",
+	start = "start",
+	catchException = "catch", // 
+	observe = "observe",
 }
 
 export interface Property<Name extends string, Value = any> {
 	name: Name;
-	role: Role.event | Role.notify;
+	role: Role.event | Role.notify | Role.observe | Role.start;
 	sticky?: boolean;
 	stickyLast?: boolean;
 	emittedType?: Value;
+}
+
+export interface PropertyDescriptor<Name extends string> {
+	name: Name;
+	role: Role.event | Role.notify | Role.observe | Role.start;
+	sticky?: boolean;
+	stickyLast?: boolean;
 }
 
 type Omit<T, K> = { [key in Exclude<keyof T, K>]: T[key] };
@@ -20,7 +28,7 @@ export interface DefaultInterfaces<DoneType = void, ErrorType = Error> {
 	done: DoneType;
 	error: ErrorType;
 	catch: Error;
-	always: DoneType | ErrorType | Error;
+	always: DoneType | ErrorType;
 	event: any;
 	notify: any
 	tap: {
@@ -31,24 +39,16 @@ export interface DefaultInterfaces<DoneType = void, ErrorType = Error> {
 }
 
 type Registerer<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = (listener: (arg: Interfaces[K]) => void) => J;
-type Resolver<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = (arg: Interfaces[K]) => J;
+type Resolver<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = (arg: Interfaces[K], ...rest: unknown[]) => J;
 type Remover<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = (listener?: (arg: Interfaces[K]) => void) => J;
-type Middleware<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> = <ChangedArg extends any>(listener: (next: (arg: ChangedArg) => void, arg: Interfaces[K]) => void) =>
-	JarvisEmitter<
-		K extends "done" ?
-		ChangedArg :
-		Interfaces extends DefaultInterfaces ? Interfaces["done"] : void,
-		K extends "error" ?
-		ChangedArg :
-		Interfaces extends DefaultInterfaces ? Interfaces["error"] : void,
-		Omit<Interfaces, K> & { [key in K]: ChangedArg }
-	>;
+type Middleware<Interfaces, K extends keyof Interfaces, DoneType, ErrorType> = <ChangedArg = Interfaces[K]>(listener: (next: (arg: ChangedArg) => void, arg: Interfaces[K]) => void) =>
+	JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, ChangedArg>>;
 
-interface InterfaceEntry<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>> {
+interface InterfaceEntry<Interfaces, K extends keyof Interfaces, J extends JarvisEmitter<any, any, Interfaces>, DoneType, ErrorType> {
 	registerer: Registerer<Interfaces, K, J>;
 	resolver: Resolver<Interfaces, K, J>;
 	remover: Remover<Interfaces, K, J>;
-	middleware: Middleware<Interfaces, K, J>;
+	middleware: Middleware<Interfaces, K, DoneType, ErrorType>;
 	name: K;
 	role: Role;
 	purge: Function;
@@ -58,7 +58,7 @@ type ExtractJarvisEmitterDoneType<J extends JarvisEmitter<any, any>> = J extends
 type ExtractJarvisEmitterErrorType<J extends JarvisEmitter<any, any>> = J extends JarvisEmitter<any, infer ErrorType> ? ErrorType : Error;
 
 declare class JarvisEmitter<DoneType = void, ErrorType = Error, Interfaces = DefaultInterfaces<DoneType, ErrorType>> {
-	constructor();
+	constructor(interfaceDescriptor?: Property<string, any>[]);
 	on: {
 		[key in keyof Interfaces]: Registerer<Interfaces, key, JarvisEmitter<DoneType, ErrorType, Interfaces>>
 	};
@@ -69,13 +69,18 @@ declare class JarvisEmitter<DoneType = void, ErrorType = Error, Interfaces = Def
 		[key in keyof Interfaces]: Remover<Interfaces, key, JarvisEmitter<DoneType, ErrorType, Interfaces>>
 	};
 	middleware: {
-		[key in keyof Interfaces]: Middleware<Interfaces, key, JarvisEmitter<DoneType, ErrorType, Interfaces>>
+		[key in keyof Interfaces]: Middleware<Interfaces, key, DoneType, ErrorType>
 	};
-	extend<K extends string, V extends any, T extends Property<K, V>>(interfaceProps: T): JarvisEmitter<DoneType, ErrorType, Interfaces & { [key in T["name"]]: T["emittedType"] }>;
+	extend<K extends string, V = K extends keyof Interfaces ? Interfaces[K] : void>(
+		interfaceProps: PropertyDescriptor<K> | PropertyDescriptor<K>[]
+	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, K> & Record<K, V>>;
+	extend<K extends string, V extends any, T extends Property<K, V>>(
+		interfaceProps: T | T[]
+	): JarvisEmitter<DoneType, ErrorType, Omit<Interfaces, T["name"]> & { [key in T["name"]]: T["emittedType"] }>;
 	promise(): Promise<DoneType>;
 	pipe<T extends JarvisEmitter<any, any, any>>(emitter: T): JarvisEmitter<DoneType, ErrorType, Interfaces>;
-	getRolesHandlers(role: Role): InterfaceEntry<Interfaces, keyof Interfaces, JarvisEmitter<DoneType, ErrorType, Interfaces>>[];
-	getHandlersForName<T extends keyof Interfaces>(name: T, role?: string): InterfaceEntry<Interfaces, T, JarvisEmitter<DoneType, ErrorType, Interfaces>>;
+	getRolesHandlers(role: Role, defaultsOnly?: boolean): InterfaceEntry<Interfaces, keyof Interfaces, JarvisEmitter<DoneType, ErrorType, Interfaces>, DoneType, ErrorType>[];
+	getHandlersForName<T extends keyof Interfaces>(name: T, role?: string): InterfaceEntry<Interfaces, T, JarvisEmitter<DoneType, ErrorType, Interfaces>, DoneType, ErrorType>;
 	destroy(): void;
 	static some<J extends Array<JarvisEmitter<any, any>>>(...emitters: J): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]> | undefined>, never>;
 	static all<J extends JarvisEmitter<any, any>[]>(...emitters: J): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]>>, ExtractJarvisEmitterErrorType<J[number]>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -108,10 +108,15 @@ declare class JarvisEmitter<
 	): JarvisEmitter<any, any>;
 
 	/**
-	 * Wraps a function that receives a trailing callback; injects a callback that resolves `done` on the returned emitter.
+	 * Wraps a function that receives a callback injected by `emitify` (trailing callback, `setTimeout`-style,
+	 * or a single-listener registerer such as `emitter.on.done` / `emitter.on.always`).
+	 * The injected callback forwards to `call.done` on the returned emitter; any return value from `fn` is ignored.
+	 *
+	 * Parameters use `any[]` so this accepts both classic `(a, b, cb)` APIs and `Registerer`-shaped functions whose
+	 * first argument is a typed listener — which are not assignable to `(...args: unknown[]) => void` under strict typing.
 	 */
 	static emitify(
-		fn: (...args: unknown[]) => void,
+		fn: (...args: any[]) => any,
 		resultsAsArray?: boolean,
 		cbIndex?: number,
 	): (...callArgs: unknown[]) => JarvisEmitter<any, any>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,15 +97,38 @@ declare class JarvisEmitter<
 		role?: string,
 	): InterfaceEntry<Interfaces, T, DoneType, ErrorType>;
 	destroy(): void;
+
+	/** Lowercase role string map (same values as {@link JarvisEmitter.Role}). Matches the runtime `static get role()` object. */
+	static get role(): typeof JarvisEmitter.Role;
+
+	static immediate(
+		result?: unknown,
+		role?: JarvisEmitter.Role,
+		name?: string,
+	): JarvisEmitter<any, any>;
+
+	/**
+	 * Wraps a function that receives a trailing callback; injects a callback that resolves `done` on the returned emitter.
+	 */
+	static emitify(
+		fn: (...args: unknown[]) => void,
+		resultsAsArray?: boolean,
+		cbIndex?: number,
+	): (...callArgs: unknown[]) => JarvisEmitter<any, any>;
+
+	static emitifyFromAsync<I extends any[], O>(
+		fn: (...args: I) => Promise<O>,
+	): (...callArgs: I) => JarvisEmitter<O, any>;
+
 	static some<J extends Array<JarvisEmitter<any, any>>>(
 		...emitters: J
 	): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]> | undefined>, never>;
 	static all<J extends JarvisEmitter<any, any>[]>(
 		...emitters: J
 	): JarvisEmitter<Array<ExtractJarvisEmitterDoneType<J[number]>>, ExtractJarvisEmitterErrorType<J[number]>>;
-	static emitifyFromAsync<I extends any[], O>(
-		fn: (...args: I) => Promise<O>,
-	): (...callArgs: I) => JarvisEmitter<O, any>;
+
+	static onUnhandledException(cb: (...args: unknown[]) => void): void;
+	static offUnhandledException(cb: (...args: unknown[]) => void): void;
 }
 
 declare namespace JarvisEmitter {

--- a/index.js
+++ b/index.js
@@ -328,8 +328,8 @@ class JarvisEmitter {
 	 * @memberOf JarvisEmitter
 	 */
 	pipe(pipedPromise) {
-		if (!pipedPromise || !pipedPromise) {
-			return;
+		if (!pipedPromise) {
+			return this;
 		}
 		for (const name in this._nameMap) {
 			const handler = this._nameMap[name];

--- a/index.js
+++ b/index.js
@@ -136,13 +136,18 @@ class JarvisEmitter {
 	 *
 	 * @param interfaceDescription
 	 */
+	withType() {
+		return {
+			extend: (interfaceProps) => this.extend(interfaceProps),
+		};
+	}
+
 	extend(interfaceDescription = []) {
 		if (!Array.isArray(interfaceDescription)) {
 			// eslint-disable-next-line no-param-reassign
 			interfaceDescription = [interfaceDescription];
 		}
-		for (const i in interfaceDescription) {
-			const property = interfaceDescription[i];
+		for (const property of interfaceDescription) {
 			if (undefined === property.name) {
 				continue;
 			}
@@ -170,8 +175,8 @@ class JarvisEmitter {
 				this.__assertValid();
 
 				try {
-					for (const j in callbackArray) {
-						callbackArray[j](...resolveArgs);
+					for (const cb of callbackArray) {
+						cb(...resolveArgs);
 					}
 					if (JarvisEmitter.role.done === property.role && "always" !== property.name) {
 						this.call.always(...resolveArgs);
@@ -217,9 +222,9 @@ class JarvisEmitter {
 					callbackArray.splice(0, callbackArray.length);
 					return this;
 				}
-				for (const j in callbackArray) {
+				for (let j = callbackArray.length - 1; j >= 0; j--) {
 					if (callbackArray[j] === cb) {
-						callbackArray.splice(parseInt(j, 10), 1);
+						callbackArray.splice(j, 1);
 					}
 				}
 				return this;
@@ -438,7 +443,7 @@ class JarvisEmitter {
 		if (0 === args.length) {
 			promise.call.done([]);
 		} else {
-			for (const promIdx in args) {
+			for (let promIdx = 0; promIdx < args.length; promIdx++) {
 				const prom = args[promIdx];
 				prom
 					.done((result) => {
@@ -469,7 +474,7 @@ class JarvisEmitter {
 		if (0 === args.length) {
 			emitter.call.done([]);
 		} else {
-			for (const emitterIdx in args) {
+			for (let emitterIdx = 0; emitterIdx < args.length; emitterIdx++) {
 				const em = args[emitterIdx];
 				em
 					.on.done((result) => {
@@ -577,6 +582,10 @@ JarvisEmitter.Role = {
 	notify: "notify",
 	event: "event",
 	observe: "observe",
+};
+
+JarvisEmitter.payload = function payload() {
+	return undefined;
 };
 
 module.exports = JarvisEmitter;

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ class JarvisEmitter {
 			if (undefined === property.name) {
 				continue;
 			}
-			if (undefined === property.role && -1 !== this._allowedRoles.indexOf(property.role)) {
+			if (undefined === property.role || -1 === this._allowedRoles.indexOf(property.role)) {
 				continue;
 			}
 			const registerer = property.name;
@@ -215,7 +215,7 @@ class JarvisEmitter {
 
 				if (!cb) {
 					callbackArray.splice(0, callbackArray.length);
-					return;
+					return this;
 				}
 				for (const j in callbackArray) {
 					if (callbackArray[j] === cb) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jarvis-emitter",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jarvis-emitter",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jarvis-emitter",
-	"version": "2.3.0",
+	"version": "3.0.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jarvis-emitter",
-			"version": "2.3.0",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,1255 @@
 {
 	"name": "jarvis-emitter",
-	"version": "2.0.12",
-	"lockfileVersion": 1,
+	"version": "2.2.0",
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "jarvis-emitter",
+			"version": "2.2.0",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			},
+			"devDependencies": {
+				"@types/mocha": "^5.2.5",
+				"chai": "^4.1.2",
+				"mocha": "^11.7.5",
+				"typescript": "^5.7.3"
+			}
+		},
+		"node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@types/mocha": {
+			"version": "5.2.7",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/assertion-error": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
+		"node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/chai": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+			"integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+			"dev": true,
+			"dependencies": {
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
+				"pathval": "^1.1.1",
+				"type-detect": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chalk/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"dependencies": {
+				"readdirp": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14.16.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/cliui/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+			"integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+			"dev": true,
+			"dependencies": {
+				"type-detect": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/diff": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+			"integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true
+		},
+		"node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true,
+			"bin": {
+				"flat": "cli.js"
+			}
+		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-func-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true,
+			"bin": {
+				"he": "bin/he"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"node_modules/jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+			"dev": true,
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/js-yaml": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/loupe": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+			"dev": true,
+			"dependencies": {
+				"get-func-name": "^2.0.1"
+			}
+		},
+		"node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mocha": {
+			"version": "11.7.5",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+			"integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+			"dev": true,
+			"dependencies": {
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^4.0.1",
+				"debug": "^4.3.5",
+				"diff": "^7.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^10.4.5",
+				"he": "^1.2.0",
+				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^9.0.5",
+				"ms": "^2.1.3",
+				"picocolors": "^1.1.1",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^9.2.0",
+				"yargs": "^17.7.2",
+				"yargs-parser": "^21.1.1",
+				"yargs-unparser": "^2.0.0"
+			},
+			"bin": {
+				"_mocha": "bin/_mocha",
+				"mocha": "bin/mocha.js"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/package-json-from-dist": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+			"dev": true
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/pathval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
+		},
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"node_modules/readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 14.18.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/serialize-javascript": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"dev": true,
+			"dependencies": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/string-width-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/type-detect": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/workerpool": {
+			"version": "9.3.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+			"integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+			"dev": true
+		},
+		"node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true
+		},
+		"node_modules/yargs/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	},
 	"dependencies": {
+		"@isaacs/cliui": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			}
+		},
+		"@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+			"dev": true,
+			"optional": true
+		},
 		"@types/mocha": {
-			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
-			"integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
+			"version": "5.2.7",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^2.0.1"
+			}
+		},
+		"argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
 		"assertion-error": {
@@ -17,19 +1259,18 @@
 			"dev": true
 		},
 		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
 		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"browser-stdout": {
@@ -38,221 +1279,766 @@
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
 		},
+		"camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true
+		},
 		"chai": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-			"integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+			"integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
 			"dev": true,
 			"requires": {
-				"assertion-error": "1.1.0",
-				"check-error": "1.0.2",
-				"deep-eql": "3.0.1",
-				"get-func-name": "2.0.0",
-				"pathval": "1.1.0",
-				"type-detect": "4.0.8"
+				"assertion-error": "^1.1.0",
+				"check-error": "^1.0.3",
+				"deep-eql": "^4.1.3",
+				"get-func-name": "^2.0.2",
+				"loupe": "^2.3.6",
+				"pathval": "^1.1.1",
+				"type-detect": "^4.1.0"
+			}
+		},
+		"chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"check-error": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-			"dev": true
-		},
-		"commander": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
-			"dev": true
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
-		},
-		"debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"requires": {
-				"ms": "2.0.0"
-			}
-		},
-		"deep-eql": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
 			"dev": true,
 			"requires": {
-				"type-detect": "4.0.8"
+				"get-func-name": "^2.0.2"
+			}
+		},
+		"chokidar": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+			"integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+			"dev": true,
+			"requires": {
+				"readdirp": "^4.0.1"
+			}
+		},
+		"cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"requires": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"wrap-ansi": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+					"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				}
+			}
+		},
+		"color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"requires": {
+				"color-name": "~1.1.4"
+			}
+		},
+		"color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			}
+		},
+		"debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"requires": {
+				"ms": "^2.1.3"
+			}
+		},
+		"decamelize": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+			"dev": true
+		},
+		"deep-eql": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+			"integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+			"dev": true,
+			"requires": {
+				"type-detect": "^4.0.0"
 			}
 		},
 		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+			"integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+			"dev": true
+		},
+		"eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true
+		},
+		"escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true
 		},
 		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true
 		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+		"find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			}
+		},
+		"flat": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+			"integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+			"dev": true
+		},
+		"foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			}
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
 		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
 			}
 		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
-			"dev": true
-		},
 		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
 		},
 		"he": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-			"integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
 		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+		"is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true
+		},
+		"is-path-inside": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+			"dev": true
+		},
+		"is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"dev": true
+		},
+		"is-unicode-supported": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true
+		},
+		"jackspeak": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"@isaacs/cliui": "^8.0.2",
+				"@pkgjs/parseargs": "^0.11.0"
 			}
 		},
-		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+		"js-yaml": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"dev": true,
+			"requires": {
+				"argparse": "^2.0.1"
+			}
+		},
+		"locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^5.0.0"
+			}
+		},
+		"log-symbols": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0",
+				"is-unicode-supported": "^0.1.0"
+			}
+		},
+		"loupe": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+			"dev": true,
+			"requires": {
+				"get-func-name": "^2.0.1"
+			}
+		},
+		"lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
 			"dev": true
 		},
 		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"version": "9.0.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+			"integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^2.0.2"
 			}
 		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+		"minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true
 		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true,
-			"requires": {
-				"minimist": "0.0.8"
-			}
-		},
 		"mocha": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-			"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+			"version": "11.7.5",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
+			"integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
 			"dev": true,
 			"requires": {
-				"browser-stdout": "1.3.1",
-				"commander": "2.15.1",
-				"debug": "3.1.0",
-				"diff": "3.5.0",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.2",
-				"growl": "1.10.5",
-				"he": "1.1.1",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"supports-color": "5.4.0"
+				"browser-stdout": "^1.3.1",
+				"chokidar": "^4.0.1",
+				"debug": "^4.3.5",
+				"diff": "^7.0.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-up": "^5.0.0",
+				"glob": "^10.4.5",
+				"he": "^1.2.0",
+				"is-path-inside": "^3.0.3",
+				"js-yaml": "^4.1.0",
+				"log-symbols": "^4.1.0",
+				"minimatch": "^9.0.5",
+				"ms": "^2.1.3",
+				"picocolors": "^1.1.1",
+				"serialize-javascript": "^6.0.2",
+				"strip-json-comments": "^3.1.1",
+				"supports-color": "^8.1.1",
+				"workerpool": "^9.2.0",
+				"yargs": "^17.7.2",
+				"yargs-parser": "^21.1.1",
+				"yargs-unparser": "^2.0.0"
 			}
 		},
 		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+		"p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"yocto-queue": "^0.1.0"
 			}
 		},
-		"path-is-absolute": {
+		"p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^3.0.2"
+			}
+		},
+		"package-json-from-dist": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"dev": true
 		},
+		"path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true
+		},
+		"path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true
+		},
+		"path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"requires": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			}
+		},
 		"pathval": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-			"integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+			"dev": true
+		},
+		"picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
+			}
+		},
+		"readdirp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+			"integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+			"dev": true
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true
+		},
+		"serialize-javascript": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
+			}
+		},
+		"shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^3.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true
+		},
+		"string-width": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+			"dev": true,
+			"requires": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			}
+		},
+		"string-width-cjs": {
+			"version": "npm:string-width@4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"requires": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				}
+			}
+		},
+		"strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^6.2.2"
+			}
+		},
+		"strip-ansi-cjs": {
+			"version": "npm:strip-ansi@6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^5.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				}
+			}
+		},
+		"strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true
 		},
 		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^4.0.0"
 			}
 		},
 		"type-detect": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+			"integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
-			"integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true
 		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+		"which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"workerpool": {
+			"version": "9.3.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+			"integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+			"dev": true
+		},
+		"wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+					"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+					"dev": true
+				}
+			}
+		},
+		"wrap-ansi-cjs": {
+			"version": "npm:wrap-ansi@7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				}
+			}
+		},
+		"y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"requires": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true
+		},
+		"yargs-unparser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+			"integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^6.0.0",
+				"decamelize": "^4.0.0",
+				"flat": "^5.0.2",
+				"is-plain-obj": "^2.1.0"
+			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jarvis-emitter",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Jarvis Emitter",
 	"main": "index",
 	"typings": "index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jarvis-emitter",
-	"version": "2.3.0",
+	"version": "3.0.0",
 	"description": "Jarvis Emitter",
 	"main": "index",
 	"typings": "index",

--- a/package.json
+++ b/package.json
@@ -1,22 +1,23 @@
 {
 	"name": "jarvis-emitter",
-	"version": "2.1.4",
+	"version": "2.2.0",
 	"description": "Jarvis Emitter",
 	"main": "index",
 	"typings": "index",
 	"scripts": {
-		"test": "mocha test/test.functionality.js"
+		"test": "mocha test/test.functionality.js",
+		"test:types": "tsc --noEmit test/test.types.ts"
 	},
 	"author": "mce",
 	"dependencies": {
-		"debug": "^3.1.0"
+		"debug": "^4.1.1"
 	},
 	"license": "MIT",
 	"devDependencies": {
 		"@types/mocha": "^5.2.5",
 		"chai": "^4.1.2",
-		"mocha": "^5.2.0",
-		"typescript": "^3.2.4"
+		"mocha": "^11.7.5",
+		"typescript": "^5.7.3"
 	},
 	"repository": {
 		"type": "git",

--- a/test/test.types.ts
+++ b/test/test.types.ts
@@ -464,7 +464,7 @@ class ServiceError extends Error { code = 0; }
 				role: Role.notify,
 			})
 			.extend({
-				name: "startXHoming",
+				name: "startYHoming",
 				role: Role.notify,
 			});
 	}

--- a/test/test.types.ts
+++ b/test/test.types.ts
@@ -199,6 +199,14 @@ class ServiceError extends Error { code = 0; }
 	>>;
 }
 
+// ─── 11b. emitify + JarvisEmitter registerer (`on.always`, `on.done`, …) ───────
+
+{
+	const em = new JarvisEmitter<void, Error>();
+	JarvisEmitter.emitify(em.on.always)();
+	JarvisEmitter.emitify(em.on.done)();
+}
+
 // ─── 12. promise() returns Promise<DoneType> ──────────────────────────────────
 
 {

--- a/test/test.types.ts
+++ b/test/test.types.ts
@@ -282,7 +282,7 @@ class ServiceError extends Error { code = 0; }
 		const _b: number = data.b;
 	});
 	sensor.on.error((err) => {
-		const _err = err; // error type is ServiceError
+		const _err = err; // error type is NewError
 	});
 }
 

--- a/test/test.types.ts
+++ b/test/test.types.ts
@@ -1,4 +1,4 @@
-import JarvisEmitter, { DefaultInterfaces, Role, Property } from "..";
+import JarvisEmitter, { DefaultInterfaces, Role, Property, payload } from "..";
 
 // ─── helpers ───────────────────────────────────────────────────────────────────
 
@@ -8,12 +8,12 @@ type Assert<T extends true> = T;
 interface GyroscopeData { x: number; y: number; z: number }
 class ServiceError extends Error { code = 0; }
 
-// ─── 1. extend — generic overload (new style) ─────────────────────────────────
+// ─── 1. extend — withType (explicit payload type) ────────────────────────────
 
-// 1a. Explicit K + V
+// 1a. withType + extend
 {
 	const em = new JarvisEmitter<void, Error>()
-		.extend<"action", string>({ name: "action", role: Role.event });
+		.withType<string>().extend({ name: "action", role: Role.event });
 
 	type _on = Assert<AssertEqual<Parameters<Parameters<typeof em.on.action>[0]>[0], string>>;
 	type _call = Assert<AssertEqual<Parameters<typeof em.call.action>[0], string>>;
@@ -39,11 +39,11 @@ class ServiceError extends Error { code = 0; }
 	type _b = Assert<AssertEqual<Parameters<Parameters<typeof em.on.b>[0]>[0], void>>;
 }
 
-// ─── 2. extend — legacy emittedType overload ───────────────────────────────────
+// ─── 2. extend — payload() + emittedType ───────────────────────────────────────
 
 {
 	const em = new JarvisEmitter<void, Error>()
-		.extend({ name: "data", role: Role.event, emittedType: 0 as number });
+		.extend({ name: "data", role: Role.event, emittedType: payload<number>() });
 
 	type _on = Assert<AssertEqual<Parameters<Parameters<typeof em.on.data>[0]>[0], number>>;
 }
@@ -78,7 +78,7 @@ class ServiceError extends Error { code = 0; }
 	>>;
 }
 
-// ─── 4. extend — generic V overrides class-level Interfaces ────────────────────
+// ─── 4. extend — withType overrides class-level Interfaces ─────────────────────
 
 {
 	interface MyInterfaces extends DefaultInterfaces<void, Error> {
@@ -86,7 +86,7 @@ class ServiceError extends Error { code = 0; }
 	}
 
 	const em = new JarvisEmitter<void, Error, MyInterfaces>()
-		.extend<"action", number>({ name: "action", role: Role.event });
+		.withType<number>().extend({ name: "action", role: Role.event });
 
 	type _overridden = Assert<AssertEqual<
 		Parameters<Parameters<typeof em.on.action>[0]>[0],
@@ -135,13 +135,13 @@ class ServiceError extends Error { code = 0; }
 	>>;
 }
 
-// ─── 7. chained extend calls ───────────────────────────────────────────────────
+// ─── 7. chained extend calls (withType) ───────────────────────────────────────
 
 {
 	const em = new JarvisEmitter<void, Error>()
-		.extend<"a", number>({ name: "a", role: Role.event })
-		.extend<"b", string>({ name: "b", role: Role.notify })
-		.extend<"c", boolean>({ name: "c", role: Role.event });
+		.withType<number>().extend({ name: "a", role: Role.event })
+		.withType<string>().extend({ name: "b", role: Role.notify })
+		.withType<boolean>().extend({ name: "c", role: Role.event });
 
 	type _a = Assert<AssertEqual<Parameters<Parameters<typeof em.on.a>[0]>[0], number>>;
 	type _b = Assert<AssertEqual<Parameters<Parameters<typeof em.on.b>[0]>[0], string>>;
@@ -153,7 +153,7 @@ class ServiceError extends Error { code = 0; }
 
 {
 	const em = new JarvisEmitter<string, Error>();
-	em.call.done("result", 1 as unknown, 2 as unknown);
+	em.call.done("result", 1, 2);
 }
 
 // ─── 9. Remover with optional listener ─────────────────────────────────────────
@@ -188,9 +188,7 @@ class ServiceError extends Error { code = 0; }
 // ─── 11. emitifyFromAsync ──────────────────────────────────────────────────────
 
 {
-	async function fetchData(url: string): Promise<{ data: string }> {
-		return { data: url };
-	}
+	const fetchData = async (url: string): Promise<{ data: string }> => ({ data: url });
 
 	const emitified = JarvisEmitter.emitifyFromAsync(fetchData);
 	const em = emitified("http://example.com");
@@ -214,7 +212,7 @@ class ServiceError extends Error { code = 0; }
 
 {
 	const props: Property<"custom", string>[] = [
-		{ name: "custom", role: Role.event, emittedType: "" }
+		{ name: "custom", role: Role.event, emittedType: "" },
 	];
 	const em = new JarvisEmitter(props);
 }
@@ -237,11 +235,10 @@ class ServiceError extends Error { code = 0; }
 	}
 	type SensorEmitter = JarvisEmitter<void, ServiceError, SensorInterfaces>;
 
-	function createSensorEmitter(): SensorEmitter {
-		return new JarvisEmitter<void, ServiceError, SensorInterfaces>()
+	const createSensorEmitter = (): SensorEmitter =>
+		new JarvisEmitter<void, ServiceError, SensorInterfaces>()
 			.extend({ name: "sensorData", role: Role.event })
 			.extend({ name: "stop", role: Role.notify });
-	}
 
 	const sensor = createSensorEmitter();
 	sensor.on.sensorData((data) => {
@@ -262,16 +259,15 @@ class ServiceError extends Error { code = 0; }
 	type NewError = { newCode: number };
 	type SensorEmitter = JarvisEmitter<void, NewError, SensorInterfaces>;
 
-	function createSensorEmitter(): SensorEmitter {
-		return new JarvisEmitter<SensorInterfaces["done"], SensorInterfaces["error"]>()
-			.extend<"sensorData", GyroscopeData>({ name: "sensorData", role: Role.event })
-			.extend<"stop", void>({ name: "stop", role: Role.notify })
-			.extend<"someEvent", { a: string, b: number }>({ name: "someEvent", role: Role.event })
+	const createSensorEmitter = (): SensorEmitter =>
+		new JarvisEmitter<void, NewError, SensorInterfaces>()
+			.extend({ name: "sensorData", role: Role.event })
+			.extend({ name: "stop", role: Role.notify })
+			.extend({ name: "someEvent", role: Role.event })
 			.middleware.error((next, err) => {
 				const newErr = { ...err, newCode: 1 };
 				next(newErr);
 			});
-	}
 
 	const sensor = createSensorEmitter();
 	sensor.on.sensorData((data) => {
@@ -282,8 +278,57 @@ class ServiceError extends Error { code = 0; }
 		const _b: number = data.b;
 	});
 	sensor.on.error((err) => {
-		const _err = err; // error type is NewError
+		const _err = err;
 	});
+}
+
+// ─── 16. withType vs payload (equivalent typing for new keys) ─────────────────
+
+{
+	const withTypeEm = new JarvisEmitter<void, Error>()
+		.withType<{ id: number }>().extend({ name: "action", role: Role.event });
+
+	type _withTypeOn = Assert<AssertEqual<
+		Parameters<Parameters<typeof withTypeEm.on.action>[0]>[0],
+		{ id: number }
+	>>;
+
+	const payloadEm = new JarvisEmitter<void, Error>()
+		.extend({ name: "action2", role: Role.event, emittedType: payload<{ id: number }>() });
+
+	type _payloadOn = Assert<AssertEqual<
+		Parameters<Parameters<typeof payloadEm.on.action2>[0]>[0],
+		{ id: number }
+	>>;
+}
+
+{
+	// Chained return values carry extended interface; assigning to a `const` and calling
+	// `.extend()` on the same variable does not update the variable's type (TS limitation).
+	const em = new JarvisEmitter<void, Error>()
+		.withType<string>().extend({ name: "aaa", role: Role.event })
+		.withType<number>().extend({ name: "bbb", role: Role.notify })
+		.withType<boolean>().extend({ name: "ccc", role: Role.event });
+	em.on.aaa((data) => {
+		const _a: string = data;
+	});
+	em.on.bbb((data) => {
+		const _b: number = data;
+	});
+	em.on.ccc((data) => {
+		const _c: boolean = data;
+	});
+
+	const em2 = new JarvisEmitter<void, Error>();
+	em2.extend({ name: "aaa", role: Role.event });
+	em2.extend({ name: "bbb", role: Role.notify });
+	em2.extend({ name: "ccc", role: Role.event });
+	// @ts-expect-error Sequential .extend() does not narrow em2's type; use chaining or withType on the chain.
+	em2.on.aaa((_data) => { });
+	// @ts-expect-error Sequential .extend() does not narrow em2's type.
+	em2.on.bbb((_data) => { });
+	// @ts-expect-error Sequential .extend() does not narrow em2's type.
+	em2.on.ccc((_data) => { });
 }
 
 //---- complex case ----
@@ -293,7 +338,7 @@ class ServiceError extends Error { code = 0; }
 		homed = "homed",
 		error = "error",
 	}
-	
+
 	interface PlcId {
 		ipAddress: string;
 		port: number;
@@ -394,8 +439,8 @@ class ServiceError extends Error { code = 0; }
 	type FullXyPlcInterfaces = DefaultInterfaces<XyPlcDoneType, Error> & XyPlcEmitterInterfaces;
 	type XyPlcEmitter = JarvisEmitter<XyPlcDoneType, Error, FullXyPlcInterfaces>;
 
-	function createXyPlcEmitter(): XyPlcEmitter {
-		return new JarvisEmitter<XyPlcDoneType, Error, FullXyPlcInterfaces>()
+	const createXyPlcEmitter = (): XyPlcEmitter => {
+		const emitter = new JarvisEmitter<XyPlcDoneType, Error, FullXyPlcInterfaces>()
 			.extend({
 				name: "ready",
 				role: Role.event,
@@ -467,5 +512,6 @@ class ServiceError extends Error { code = 0; }
 				name: "startYHoming",
 				role: Role.notify,
 			});
-	}
+		return emitter;
+	};
 }

--- a/test/test.types.ts
+++ b/test/test.types.ts
@@ -15,7 +15,7 @@ class ServiceError extends Error { code = 0; }
 	const em = new JarvisEmitter<void, Error>()
 		.extend<"action", string>({ name: "action", role: Role.event });
 
-	type _on  = Assert<AssertEqual<Parameters<Parameters<typeof em.on.action>[0]>[0], string>>;
+	type _on = Assert<AssertEqual<Parameters<Parameters<typeof em.on.action>[0]>[0], string>>;
 	type _call = Assert<AssertEqual<Parameters<typeof em.call.action>[0], string>>;
 }
 
@@ -160,7 +160,7 @@ class ServiceError extends Error { code = 0; }
 
 {
 	const em = new JarvisEmitter<string, Error>();
-	const listener = (_arg: string) => {};
+	const listener = (_arg: string) => { };
 	em.on.done(listener);
 	em.off.done(listener);
 	em.off.done();
@@ -259,7 +259,7 @@ class ServiceError extends Error { code = 0; }
 		someEvent: { a: string, b: number };
 		stop: void;
 	}
-	type NewError =  { newCode: number };
+	type NewError = { newCode: number };
 	type SensorEmitter = JarvisEmitter<void, NewError, SensorInterfaces>;
 
 	function createSensorEmitter(): SensorEmitter {
@@ -284,4 +284,188 @@ class ServiceError extends Error { code = 0; }
 	sensor.on.error((err) => {
 		const _err = err; // error type is ServiceError
 	});
+}
+
+//---- complex case ----
+{
+	enum HomingStatus {
+		homing = "homing",
+		homed = "homed",
+		error = "error",
+	}
+	
+	interface PlcId {
+		ipAddress: string;
+		port: number;
+	}
+
+	interface RadiantId {
+		ipAddress: string;
+		port: number;
+	}
+
+	type XyPlcDoneType = Record<string, unknown> | {
+		movedTo: {
+			fingerId: number;
+			x: number;
+			y: number;
+		};
+	} | HomingStatus;
+
+	interface XyPlcEmitterInterfaces {
+		ready: void;
+		moveXy: {
+			plcId: PlcId;
+			fingerId: number;
+			x: number;
+			y: number;
+		};
+		moveX: {
+			plcId: PlcId;
+			fingerId: number;
+			x: number;
+		};
+		moveY: {
+			plcId: PlcId;
+			fingerId: number;
+			y: number;
+		};
+		getXPosition: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		getYPosition: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		setFingerHeight: {
+			plcId: PlcId;
+			fingerId: number;
+			height: number;
+		};
+		getZPosition: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		changeFingerType: {
+			plcId: PlcId;
+			fingerId: number;
+			fingerTypeIndex: number;
+		};
+		getActiveFingerType: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		moveSupportPlatform: {
+			plcId: PlcId;
+			cellId: number;
+			requiredPos: number;
+		};
+		getSupportPlatformPosition: {
+			plcId: PlcId;
+			cellId: number;
+		};
+		startHoming: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		getHomingXStatus: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		getHomingYStatus: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		getHomingZStatus: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		startXHoming: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+		startYHoming: {
+			plcId: PlcId;
+			fingerId: number;
+		};
+	}
+
+	type FullXyPlcInterfaces = DefaultInterfaces<XyPlcDoneType, Error> & XyPlcEmitterInterfaces;
+	type XyPlcEmitter = JarvisEmitter<XyPlcDoneType, Error, FullXyPlcInterfaces>;
+
+	function createXyPlcEmitter(): XyPlcEmitter {
+		return new JarvisEmitter<XyPlcDoneType, Error, FullXyPlcInterfaces>()
+			.extend({
+				name: "ready",
+				role: Role.event,
+				sticky: true,
+			}).extend({
+				name: "moveXy",
+				role: Role.notify,
+			}).extend({
+				name: "moveX",
+				role: Role.notify,
+			})
+			.extend({
+				name: "moveY",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getXPosition",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getYPosition",
+				role: Role.notify,
+			})
+			.extend({
+				name: "setFingerHeight",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getZPosition",
+				role: Role.notify,
+			})
+			.extend({
+				name: "changeFingerType",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getActiveFingerType",
+				role: Role.notify,
+			})
+			.extend({
+				name: "moveSupportPlatform",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getSupportPlatformPosition",
+				role: Role.notify,
+			})
+			.extend({
+				name: "startHoming",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getHomingXStatus",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getHomingYStatus",
+				role: Role.notify,
+			})
+			.extend({
+				name: "getHomingZStatus",
+				role: Role.notify,
+			})
+			.extend({
+				name: "startXHoming",
+				role: Role.notify,
+			})
+			.extend({
+				name: "startXHoming",
+				role: Role.notify,
+			});
+	}
 }

--- a/test/test.types.ts
+++ b/test/test.types.ts
@@ -1,0 +1,287 @@
+import JarvisEmitter, { DefaultInterfaces, Role, Property } from "..";
+
+// ─── helpers ───────────────────────────────────────────────────────────────────
+
+type AssertEqual<T, U> = [T] extends [U] ? [U] extends [T] ? true : false : false;
+type Assert<T extends true> = T;
+
+interface GyroscopeData { x: number; y: number; z: number }
+class ServiceError extends Error { code = 0; }
+
+// ─── 1. extend — generic overload (new style) ─────────────────────────────────
+
+// 1a. Explicit K + V
+{
+	const em = new JarvisEmitter<void, Error>()
+		.extend<"action", string>({ name: "action", role: Role.event });
+
+	type _on  = Assert<AssertEqual<Parameters<Parameters<typeof em.on.action>[0]>[0], string>>;
+	type _call = Assert<AssertEqual<Parameters<typeof em.call.action>[0], string>>;
+}
+
+// 1b. V defaults to void for new keys
+{
+	const em = new JarvisEmitter<void, Error>()
+		.extend({ name: "stop", role: Role.notify });
+
+	type _on = Assert<AssertEqual<Parameters<Parameters<typeof em.on.stop>[0]>[0], void>>;
+}
+
+// 1c. Array of descriptors
+{
+	const em = new JarvisEmitter<void, Error>()
+		.extend([
+			{ name: "a" as const, role: Role.event },
+			{ name: "b" as const, role: Role.notify },
+		]);
+
+	type _a = Assert<AssertEqual<Parameters<Parameters<typeof em.on.a>[0]>[0], void>>;
+	type _b = Assert<AssertEqual<Parameters<Parameters<typeof em.on.b>[0]>[0], void>>;
+}
+
+// ─── 2. extend — legacy emittedType overload ───────────────────────────────────
+
+{
+	const em = new JarvisEmitter<void, Error>()
+		.extend({ name: "data", role: Role.event, emittedType: 0 as number });
+
+	type _on = Assert<AssertEqual<Parameters<Parameters<typeof em.on.data>[0]>[0], number>>;
+}
+
+// ─── 3. extend — class-level Interfaces + extend preserves types ───────────────
+
+{
+	interface MyInterfaces extends DefaultInterfaces<void, ServiceError> {
+		gyroscopeData: GyroscopeData;
+		stop: void;
+	}
+
+	const em = new JarvisEmitter<void, ServiceError, MyInterfaces>()
+		.extend({ name: "gyroscopeData", role: Role.event })
+		.extend({ name: "stop", role: Role.notify });
+
+	type _gyro = Assert<AssertEqual<
+		Parameters<Parameters<typeof em.on.gyroscopeData>[0]>[0],
+		GyroscopeData
+	>>;
+	type _stop = Assert<AssertEqual<
+		Parameters<Parameters<typeof em.on.stop>[0]>[0],
+		void
+	>>;
+	type _done = Assert<AssertEqual<
+		Parameters<Parameters<typeof em.on.done>[0]>[0],
+		void
+	>>;
+	type _err = Assert<AssertEqual<
+		Parameters<Parameters<typeof em.on.error>[0]>[0],
+		ServiceError
+	>>;
+}
+
+// ─── 4. extend — generic V overrides class-level Interfaces ────────────────────
+
+{
+	interface MyInterfaces extends DefaultInterfaces<void, Error> {
+		action: string;
+	}
+
+	const em = new JarvisEmitter<void, Error, MyInterfaces>()
+		.extend<"action", number>({ name: "action", role: Role.event });
+
+	type _overridden = Assert<AssertEqual<
+		Parameters<Parameters<typeof em.on.action>[0]>[0],
+		number
+	>>;
+}
+
+// ─── 5. middleware — preserves DoneType / ErrorType ────────────────────────────
+
+{
+	interface MyInterfaces extends DefaultInterfaces<void, ServiceError> {
+		data: string;
+		stop: void;
+	}
+
+	const em = new JarvisEmitter<void, ServiceError, MyInterfaces>()
+		.extend({ name: "data", role: Role.event })
+		.extend({ name: "stop", role: Role.notify });
+
+	const piped = em.middleware.error((next, err) => {
+		next(new ServiceError(err.message));
+	});
+
+	type _errType = Assert<AssertEqual<
+		Parameters<Parameters<typeof piped.on.error>[0]>[0],
+		ServiceError
+	>>;
+	type _dataType = Assert<AssertEqual<
+		Parameters<Parameters<typeof piped.on.data>[0]>[0],
+		string
+	>>;
+}
+
+// ─── 6. middleware — default ChangedArg preserves existing type ─────────────────
+
+{
+	const em = new JarvisEmitter<string, Error>();
+
+	const piped = em.middleware.done((next, val) => {
+		next(val);
+	});
+
+	type _done = Assert<AssertEqual<
+		Parameters<Parameters<typeof piped.on.done>[0]>[0],
+		string
+	>>;
+}
+
+// ─── 7. chained extend calls ───────────────────────────────────────────────────
+
+{
+	const em = new JarvisEmitter<void, Error>()
+		.extend<"a", number>({ name: "a", role: Role.event })
+		.extend<"b", string>({ name: "b", role: Role.notify })
+		.extend<"c", boolean>({ name: "c", role: Role.event });
+
+	type _a = Assert<AssertEqual<Parameters<Parameters<typeof em.on.a>[0]>[0], number>>;
+	type _b = Assert<AssertEqual<Parameters<Parameters<typeof em.on.b>[0]>[0], string>>;
+	type _c = Assert<AssertEqual<Parameters<Parameters<typeof em.on.c>[0]>[0], boolean>>;
+	type _done = Assert<AssertEqual<Parameters<Parameters<typeof em.on.done>[0]>[0], void>>;
+}
+
+// ─── 8. Resolver is variadic ───────────────────────────────────────────────────
+
+{
+	const em = new JarvisEmitter<string, Error>();
+	em.call.done("result", 1 as unknown, 2 as unknown);
+}
+
+// ─── 9. Remover with optional listener ─────────────────────────────────────────
+
+{
+	const em = new JarvisEmitter<string, Error>();
+	const listener = (_arg: string) => {};
+	em.on.done(listener);
+	em.off.done(listener);
+	em.off.done();
+}
+
+// ─── 10. static all / some preserve types ──────────────────────────────────────
+
+{
+	const a = new JarvisEmitter<string, Error>();
+	const b = new JarvisEmitter<number, Error>();
+
+	const all = JarvisEmitter.all(a, b);
+	type _allDone = Assert<AssertEqual<
+		Parameters<Parameters<typeof all.on.done>[0]>[0],
+		(string | number)[]
+	>>;
+
+	const some = JarvisEmitter.some(a, b);
+	type _someDone = Assert<AssertEqual<
+		Parameters<Parameters<typeof some.on.done>[0]>[0],
+		(string | number | undefined)[]
+	>>;
+}
+
+// ─── 11. emitifyFromAsync ──────────────────────────────────────────────────────
+
+{
+	async function fetchData(url: string): Promise<{ data: string }> {
+		return { data: url };
+	}
+
+	const emitified = JarvisEmitter.emitifyFromAsync(fetchData);
+	const em = emitified("http://example.com");
+
+	type _done = Assert<AssertEqual<
+		Parameters<Parameters<typeof em.on.done>[0]>[0],
+		{ data: string }
+	>>;
+}
+
+// ─── 12. promise() returns Promise<DoneType> ──────────────────────────────────
+
+{
+	const em = new JarvisEmitter<number, Error>();
+	const p = em.promise();
+
+	type _p = Assert<AssertEqual<typeof p, Promise<number>>>;
+}
+
+// ─── 13. constructor accepts Property array ────────────────────────────────────
+
+{
+	const props: Property<"custom", string>[] = [
+		{ name: "custom", role: Role.event, emittedType: "" }
+	];
+	const em = new JarvisEmitter(props);
+}
+
+// ─── 14. getRolesHandlers accepts defaultsOnly ─────────────────────────────────
+
+{
+	const em = new JarvisEmitter();
+	em.getRolesHandlers(Role.event);
+	em.getRolesHandlers(Role.event, true);
+	em.getRolesHandlers(Role.event, false);
+}
+
+// ─── 15. full factory pattern (matches real-world usage) ───────────────────────
+
+{
+	interface SensorInterfaces extends DefaultInterfaces<void, ServiceError> {
+		sensorData: GyroscopeData;
+		stop: void;
+	}
+	type SensorEmitter = JarvisEmitter<void, ServiceError, SensorInterfaces>;
+
+	function createSensorEmitter(): SensorEmitter {
+		return new JarvisEmitter<void, ServiceError, SensorInterfaces>()
+			.extend({ name: "sensorData", role: Role.event })
+			.extend({ name: "stop", role: Role.notify });
+	}
+
+	const sensor = createSensorEmitter();
+	sensor.on.sensorData((data) => {
+		const _x: number = data.x;
+	});
+	sensor.middleware.error((next, err) => {
+		next(new ServiceError(err.message));
+	});
+}
+
+
+{
+	interface SensorInterfaces extends DefaultInterfaces<void, NewError> {
+		sensorData: GyroscopeData;
+		someEvent: { a: string, b: number };
+		stop: void;
+	}
+	type NewError =  { newCode: number };
+	type SensorEmitter = JarvisEmitter<void, NewError, SensorInterfaces>;
+
+	function createSensorEmitter(): SensorEmitter {
+		return new JarvisEmitter<SensorInterfaces["done"], SensorInterfaces["error"]>()
+			.extend<"sensorData", GyroscopeData>({ name: "sensorData", role: Role.event })
+			.extend<"stop", void>({ name: "stop", role: Role.notify })
+			.extend<"someEvent", { a: string, b: number }>({ name: "someEvent", role: Role.event })
+			.middleware.error((next, err) => {
+				const newErr = { ...err, newCode: 1 };
+				next(newErr);
+			});
+	}
+
+	const sensor = createSensorEmitter();
+	sensor.on.sensorData((data) => {
+		const _x: number = data.x;
+	});
+	sensor.on.someEvent((data) => {
+		const _a: string = data.a;
+		const _b: number = data.b;
+	});
+	sensor.on.error((err) => {
+		const _err = err; // error type is ServiceError
+	});
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"strict": true,
+		"noEmit": true,
+		"moduleResolution": "node",
+		"target": "ES2017",
+		"module": "commonjs",
+		"esModuleInterop": true
+	},
+	"include": ["test/test.types.ts", "index.d.ts"]
+}


### PR DESCRIPTION
## Summary

**Release 2.3.0** — runtime fixes for `extend` and listener iteration, a TypeScript API overhaul (`Simplify`, `withType`, `payload`), compile-only type tests, and expanded documentation. This PR compares **`extend-and-middleware-fix`** → **`master`** ([diff vs `master`](https://github.com/mceSystems/jarvis-emitter/compare/master...extend-and-middleware-fix)).

| Metric | Value |
|--------|------:|
| Commits (on branch) | 9 |
| Files changed | 8 |
| Lines | +3 148 / −245 |

> There is no `develop` branch in this repo; **`master` is the integration base** for this change.

---

## Motivation

1. **Runtime:** `extend` used a broken role guard (`undefined === property.role && …`) so valid descriptors were skipped; `Role.observe` / `start`-style roles did not behave as intended. Listener arrays were iterated with `for…in` (unsafe for arrays). `off.*()` with no listener did not return `this`; `pipe()` was not reliably chainable when the argument was missing.
2. **Types:** Declarations were out of sync with JS (static helpers, variadic `call`, `purge`, merged namespace). Heavy `Omit`/`Record` intersections from `extend` and middleware were hard to read in tooltips.
3. **DX:** Callers need a **type-safe** way to attach payload types to new event names **without** the old `extend<'name', Type>(…)` generic pattern and **without** type assertions.

---

## Breaking changes (2.2 → 2.3)

- **`extend<'key', Type>(…)` is removed.** Use either:
  - **`withType<T>().extend({ name, role })`** — best for long chains, or
  - **`extend({ name, role, emittedType: payload<T>() })`** — inline on the descriptor.
- **`PropertyDescriptor`** uses **`emittedType?: never`** so overloads distinguish “descriptor only” vs `Property` + `payload()`.
- New keys added with a **plain** descriptor (no `withType` / `payload` / interface map entry) are typed with payload **`void`**.

---

## Runtime (`index.js`)

| Area | Change |
|------|--------|
| **`extend`** | Correct role filtering: **`undefined === property.role ||` role not in `_allowedRoles`** → skip; iterate descriptors with **`for…of`**; invoke listeners with **`for…of`**. |
| **`off` / remover** | Purge-all returns **`this`**; remove-one loop walks the callback array **backwards** while splicing. |
| **`pipe`** | Missing / falsy piped emitter returns **`this`** for chaining. |
| **`static all` / `static some`** | Index **`for` loops** instead of `for…in` over argument arrays. |
| **`withType()`** | Returns `{ extend: (props) => this.extend(props) }` for typed chaining. |
| **`JarvisEmitter.payload`** | Runtime stub returning `undefined` (types use it as a marker for `emittedType`). |

---

## Types (`index.d.ts`)

- **`Simplify<T>`** — flattens intersections from `extend` / middleware results.
- **`extend` overloads** — distinguish existing vs new keys; descriptor-only vs full `Property` + `emittedType`; integration with **`withType()`**.
- **`Middleware`** — return type uses **`Simplify<…>`**.
- **`InterfaceEntry.purge`** — **`() => void`** (not `Function`).
- **Statics** aligned with JS: **`role` getter**, **`immediate`**, **`emitify`**, **`onUnhandledException`**, **`offUnhandledException`**, plus existing **`some` / `all` / `emitifyFromAsync`**.
- **Namespace:** **`payload(): T`** for use in descriptors.
- **`Role.observe`** spelling corrected vs the old typings typo **`obsereve`**.

---

## Tooling & docs

| File | Purpose |
|------|---------|
| `tsconfig.json` | Strict check for `index.d.ts` + `test/test.types.ts` |
| `test/test.types.ts` | Compile-only assertions (`extend`, middleware, statics, `@ts-expect-error` for non-chained `.extend` limitations) |
| `README.md` | Install/import patterns, `withType` / `payload`, chaining vs sequential `.extend`, feature overview |
| `AUDIT.md` | Runtime vs typings audit and resolution notes |
| `package.json` / `package-lock.json` | **2.3.0**, `test:types`, TypeScript **5.7.x**, Mocha **11.x** |

---

## Files touched (vs `master`)

- `index.js` — runtime fixes + `withType` + `payload`
- `index.d.ts` — typings overhaul + statics + namespace
- `test/test.types.ts` — new
- `tsconfig.json` — new
- `README.md` — expanded
- `AUDIT.md` — new
- `package.json`, `package-lock.json` — version & tooling

---

## How to verify

```bash
npm test
npm run test:types
```

---

## Evidence

![CI or local verification](https://github.com/user-attachments/assets/6ec16b3f-be18-433d-9f3d-e6196820aa71)
