### PR TITLE
Bump version to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jarvis-emitter",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "Jarvis Emitter",
 	"main": "index",
 	"typings": "index",
@@ -21,6 +21,6 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/mceSystems/jarvis-emitter"
+		"url": "git+https://github.com/mceSystems/jarvis-emitter.git"
 	}
 }


### PR DESCRIPTION
## Summary
- Bump package version from 3.0.1 to 3.0.2
- Normalize repository URL to canonical `git+https://...git` form

## Note on dependabot alerts
Two open alerts (`serialize-javascript`, `diff`) come in transitively via `mocha`,
which is a devDependency. Latest mocha (11.7.5) still declares the vulnerable
ranges, so no direct dep update fixes them. Not shipped to consumers — can be
addressed when mocha bumps its declared ranges upstream.

## Test plan
- [x] `npm test` — 33 passing
- [x] `npm run test:types` — clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)