### PR TITLE
Bump version to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jarvis-emitter",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jarvis-emitter",
-			"version": "3.0.1",
+			"version": "3.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jarvis-emitter",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"description": "Jarvis Emitter",
 	"main": "index",
 	"typings": "index",
@@ -21,6 +21,6 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/mceSystems/jarvis-emitter"
+		"url": "git+https://github.com/mceSystems/jarvis-emitter.git"
 	}
 }


### PR DESCRIPTION
## Summary
- Bump package version from 3.0.1 to 3.0.2
- Normalize repository URL to canonical `git+https://...git` form

## Test plan
- [x] `npm test` — 33 passing
- [x] `npm run test:types` — clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)