### PR TITLE
fix: align payload<T>() with withType<T>() for undefined payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,19 @@
 node_modules
+dist
+
+# IDE / editor
+.idea/
+.vscode/
+.vs/
+.zed/
+.fleet/
+*.iml
+*.sublime-project
+*.sublime-workspace
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/index.d.ts
+++ b/index.d.ts
@@ -156,13 +156,19 @@ declare namespace JarvisEmitter {
 
 	/**
 	 * Descriptor without `emittedType` — use {@link payload} or {@link JarvisEmitter#withType} for payload typing.
+	 *
+	 * `emittedType` is intentionally absent: declaring it as `emittedType?: never`
+	 * silently accepted `emittedType: undefined` (from `payload<undefined>()`),
+	 * collapsing the payload to `void` instead of `undefined`. Leaving the field
+	 * out forces excess-property checking to push descriptors carrying an explicit
+	 * `emittedType` onto the `Property<K, V>` overload, so `payload<T>()` and
+	 * `withType<T>()` produce the same payload type for every `T`.
 	 */
 	interface PropertyDescriptor<Name extends string> {
 		name: Name;
 		role: Role.event | Role.notify | Role.observe | Role.start;
 		sticky?: boolean;
 		stickyLast?: boolean;
-		emittedType?: never;
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jarvis-emitter",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jarvis-emitter",
-			"version": "3.0.2",
+			"version": "3.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jarvis-emitter",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"description": "Jarvis Emitter",
 	"main": "index",
 	"typings": "index",

--- a/test/test.types.ts
+++ b/test/test.types.ts
@@ -310,6 +310,53 @@ class ServiceError extends Error { code = 0; }
 	>>;
 }
 
+// ─── 16b. payload<T>(), withType<T>(), and class-level Interfaces all agree ──
+// Regression: previously `payload<undefined>()` collapsed to `void` because
+// the descriptor matched the no-`emittedType` overload (`emittedType?: never`
+// silently accepts `undefined`). All three forms of expressing a payload type
+// must now yield the same type — including for `undefined`.
+
+{
+	// Form 1: withType<T>() chained
+	const withTypeUndef = new JarvisEmitter<void, Error>()
+		.withType<undefined>().extend({ name: "u1", role: Role.event });
+
+	type _withTypeUndef = Assert<AssertEqual<
+		Parameters<Parameters<typeof withTypeUndef.on.u1>[0]>[0],
+		undefined
+	>>;
+
+	// Form 2: payload<T>() in the descriptor's emittedType
+	const payloadUndef = new JarvisEmitter<void, Error>()
+		.extend({ name: "u2", role: Role.event, emittedType: payload<undefined>() });
+
+	type _payloadUndef = Assert<AssertEqual<
+		Parameters<Parameters<typeof payloadUndef.on.u2>[0]>[0],
+		undefined
+	>>;
+
+	// Form 3: class-level Interfaces declaration
+	interface UndefInterfaces extends DefaultInterfaces<void, Error> {
+		u3: undefined;
+	}
+	const interfaceUndef = new JarvisEmitter<void, Error, UndefInterfaces>()
+		.extend({ name: "u3", role: Role.event });
+
+	type _interfaceUndef = Assert<AssertEqual<
+		Parameters<Parameters<typeof interfaceUndef.on.u3>[0]>[0],
+		undefined
+	>>;
+
+	// Boundary: no `emittedType`, no `withType`, no class-level type — falls back to `void`.
+	const voidFallback = new JarvisEmitter<void, Error>()
+		.extend({ name: "u4", role: Role.event });
+
+	type _voidFallback = Assert<AssertEqual<
+		Parameters<Parameters<typeof voidFallback.on.u4>[0]>[0],
+		void
+	>>;
+}
+
 {
 	// Chained return values carry extended interface; assigning to a `const` and calling
 	// `.extend()` on the same variable does not update the variable's type (TS limitation).


### PR DESCRIPTION
## Why

`payload<undefined>()` produced a `void` payload type instead of `undefined`, disagreeing with `withType<undefined>()` which forced the type correctly. Minor bug — types-only, no runtime behaviour was ever wrong.

## How

Removed `emittedType?: never` from `JarvisEmitter.PropertyDescriptor` in `index.d.ts`. With the field absent, any descriptor carrying an explicit `emittedType` fails excess-property checking against `PropertyDescriptor` and overload resolution falls through to `Property<K, V>`, which forwards the inferred `V` (including `undefined`).

## How tested

- Added section 16b in `test/test.types.ts` covering all three forms (`payload<T>()`, `withType<T>()`, class-level `Interfaces`) with `T = undefined`, plus the bare-`extend` → `void` fallback boundary.
- `npm run test:types` (tsc --noEmit) passes.
- `npm test` (33 mocha runtime tests) passes — runtime is unchanged.

Patch bump 3.0.2 → 3.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)